### PR TITLE
Change the WebHook into Webhook in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ $updateInfo = array (
 $shopify->Order($orderID)->put($order);
 ```
 
-- Remove a WebHook (DELETE request)
+- Remove a Webhook (DELETE request)
 
 ```php
 $webHookID = 453487303;
 
-$shopify->WebHook($webHookID)->delete());
+$shopify->Webhook($webHookID)->delete());
 ```
 
 


### PR DESCRIPTION
Accroding to the `lib/Webhook.php`, the WebHook string is README.md should be `Webhook` instead of `WebHook`. Otherwise, the `ShopifySDK` throws "Invalid resource name WebHook. Pls check the API Reference to get the appropriate resource name." exception.