### PR TITLE
Better approach to leaky bucket rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+/nbproject/private/

--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -140,18 +140,24 @@ class CurlRequest
      */
     protected static function processRequest($ch)
     {
-        // $output contains the output string
-        $output = curl_exec($ch);
-
+        # Check for 429 leaky bucket error
+        while(1) {
+             $output = curl_exec($ch);
+             self::$lastHttpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+             if(self::$lastHttpCode != 429) {
+                break; 
+             } 
+             usleep(500000);
+        }
+    
         if (curl_errno($ch)) {
             throw new Exception\CurlException(curl_errno($ch) . ' : ' . curl_error($ch));
         }
-
-        self::$lastHttpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
         // close curl resource to free up system resources
         curl_close($ch);
 
         return $output;
     }
+    
 }

--- a/lib/HttpRequestJson.php
+++ b/lib/HttpRequestJson.php
@@ -68,7 +68,6 @@ class HttpRequestJson
     {
         self::prepareRequest($httpHeaders);
 
-        ShopifySDK::checkApiCallLimit();
         $response = CurlRequest::get($url, self::$httpHeaders);
 
         return self::processResponse($response);
@@ -87,7 +86,6 @@ class HttpRequestJson
     {
         self::prepareRequest($httpHeaders, $dataArray);
 
-        ShopifySDK::checkApiCallLimit();
         $response = CurlRequest::post($url, self::$postDataJSON, self::$httpHeaders);
 
         return self::processResponse($response);
@@ -106,7 +104,6 @@ class HttpRequestJson
     {
         self::prepareRequest($httpHeaders, $dataArray);
 
-        ShopifySDK::checkApiCallLimit();
         $response = CurlRequest::put($url, self::$postDataJSON, self::$httpHeaders);
 
         return self::processResponse($response);
@@ -124,7 +121,6 @@ class HttpRequestJson
     {
         self::prepareRequest($httpHeaders);
 
-        ShopifySDK::checkApiCallLimit();
         $response = CurlRequest::delete($url, self::$httpHeaders);
 
         return self::processResponse($response);


### PR DESCRIPTION
Hi

In our application we can have multiple processes connecting to Shopify simultaneously.  In this case the approach currently taken to manage the leaky bucket rate limit doesn't work and 429 errors can be thrown.  An alternative approach is to catch the 429 and back off for 0.5 seconds and try again.  This works well for us for those times when a small flurry of parallel connection exhaust the bucket.

Regards

Steve