### PR TITLE
Add an option to return the auth request url

### DIFF
--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -80,12 +80,13 @@ class AuthHelper
      *
      * @param string|string[] $scopes Scopes required by app
      * @param string $redirectUrl
+     * @param bool $autoRedirect
      *
      * @throws SdkException if required configuration is not provided in $config
      *
-     * @return void
+     * @return string
      */
-    public static function createAuthRequest($scopes, $redirectUrl = null)
+    public static function createAuthRequest($scopes, $redirectUrl = null, $autoRedirect = false)
     {
         $config = ShopifySDK::$config;
 
@@ -98,12 +99,12 @@ class AuthHelper
                 throw new SdkException("SharedSecret is required for getting access token. Please check SDK configuration!");
             }
 
-            //If redirect url is the same as this url, then need to check for access token when redirected back from shopify
+            // If redirect url is the same as this url, then need to check for access token when redirected back from shopify
             if(isset($_GET['code'])) {
-                return self::getAccessToken($config);
-            } else {
-                $redirectUrl = self::getCurrentUrl();
+                return self::getAccessToken();
             }
+
+            $redirectUrl = self::getCurrentUrl();
         }
 
         if (is_array($scopes)) {
@@ -111,7 +112,12 @@ class AuthHelper
         }
         $authUrl = $config['AdminUrl'] . 'oauth/authorize?client_id=' . $config['ApiKey'] . '&redirect_uri=' . $redirectUrl . "&scope=$scopes";
 
-        header("Location: $authUrl");
+        if (!$autoRedirect) {
+            header("Location: $authUrl");
+            exit;
+        }
+
+        return $authUrl;
     }
 
     /**

--- a/tests/AuthHelperTest.php
+++ b/tests/AuthHelperTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ *    ______            __             __
+ *   / ____/___  ____  / /__________  / /
+ *  / /   / __ \/ __ \/ __/ ___/ __ \/ /
+ * / /___/ /_/ / / / / /_/ /  / /_/ / /
+ * \______________/_/\__/_/   \____/_/
+ *    /   |  / / /_
+ *   / /| | / / __/
+ *  / ___ |/ / /_
+ * /_/ _|||_/\__/ __     __
+ *    / __ \___  / /__  / /____
+ *   / / / / _ \/ / _ \/ __/ _ \
+ *  / /_/ /  __/ /  __/ /_/  __/
+ * /_____/\___/_/\___/\__/\___/
+ *
+ */
+
+namespace PHPShopify;
+
+
+use PHPShopify\Exception\SdkException;
+
+class AuthHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function createAuthRequestThrowsSdkExceptionProvider()
+    {
+        return [
+            'no config' => [
+                'config' => [],
+                'message' => 'ShopUrl and ApiKey are required for authentication request. Please check SDK configuration!',
+            ],
+            'only ShopUrl' => [
+                'config' => ['ShopUrl' => ''],
+                'message' => 'ShopUrl and ApiKey are required for authentication request. Please check SDK configuration!',
+            ],
+            'ShopUrl and ApiKey' => [
+                'config' => ['ShopUrl' => '', 'ApiKey' => ''],
+                'message' => 'SharedSecret is required for getting access token. Please check SDK configuration!',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider createAuthRequestThrowsSdkExceptionProvider
+     * @param $config
+     * @param $message
+     * @throws SdkException
+     */
+    public function testCreateAuthRequestThrowsSdkException($config, $message)
+    {
+        $this->expectException(SdkException::class);
+        $this->expectExceptionMessage($message);
+
+        ShopifySDK::$config = $config;
+
+        AuthHelper::createAuthRequest('read_orders');
+    }
+
+    public function testReturnsTheRedirectUrl()
+    {
+        $_SERVER['HTTP_HOST'] = 'myshopifyapp.com';
+        $_SERVER['REQUEST_URI'] = '/test';
+
+        ShopifySDK::$config = [
+            'ShopUrl' => '',
+            'ApiKey' => '',
+            'SharedSecret' => '',
+            'AdminUrl' => 'https://test.myshopify.com/admin/',
+        ];
+
+        $url = AuthHelper::createAuthRequest('read_orders', 'https://myshopifyapp.com/app/', true);
+
+        $expected = 'https://test.myshopify.com/admin/oauth/authorize?client_id=';
+        $expected .= '&redirect_uri=https://myshopifyapp.com/app/&scope=read_orders';
+        $this->assertEquals($expected, $url);
+    }
+}


### PR DESCRIPTION
Hello,

Thanks for making this library. I noticed that the `createAuthRequest` function calls the `header` function itself to redirect. Because this is hard to test i added an `$autoRedirect` flag so we can control this behavior, and to be backward compatible.