### PR TITLE
Add User-Agent header to CURL requests

### DIFF
--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -47,6 +47,8 @@ class CurlRequest
         //Return the transfer as a string
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
+        curl_setopt($ch, CURLOPT_USERAGENT, 'PHPClassic/PHPShopify');
+
         $headers = array();
         foreach ($httpHeaders as $key => $value) {
             $headers[] = "$key: $value";


### PR DESCRIPTION
When making many requests over a short period we have noticed Shopify's API sometimes returns a 403 Forbidden error response for requests that usually work.

I have researched this and believe the requests are being caught by some kind of automated request filtering system on Shopify's servers.

Adding a User-Agent header to all CURL requests resolves this issue. I guess their automated system sees the User-Agent header and assumes it is a valid request instead of some sort of scraper.

Relevant discussion: https://ecommerce.shopify.com/c/shopify-apis-and-technology/t/suddenly-getting-forbidden-request-error-from-shopify-with-curl-411472