### PR TITLE
fix: remove static config assignments

### DIFF
--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -39,15 +39,15 @@ class AuthHelper
      *
      * @return bool
      */
-    public static function verifyShopifyRequest()
+    public static function verifyShopifyRequest( &$config )
     {
         $data = $_GET;
 
-        if(!isset(ShopifySDK::$config['SharedSecret'])) {
+        if(!isset($config['SharedSecret'])) {
             throw new SdkException("Please provide SharedSecret while configuring the SDK client.");
         }
 
-        $sharedSecret = ShopifySDK::$config['SharedSecret'];
+        $sharedSecret = $config['SharedSecret'];
 
         //Get the hmac and remove it from array
         if (isset($data['hmac'])) {
@@ -87,10 +87,8 @@ class AuthHelper
      *
      * @return void|string
      */
-    public static function createAuthRequest($scopes, $redirectUrl = null, $state = null, $options = null, $return = false)
+    public static function createAuthRequest(&$config, $scopes, $redirectUrl = null, $state = null, $options = null, $return = false)
     {
-        $config = ShopifySDK::$config;
-
         if(!isset($config['ShopUrl']) || !isset($config['ApiKey'])) {
             throw new SdkException("ShopUrl and ApiKey are required for authentication request. Please check SDK configuration!");
         }
@@ -136,10 +134,8 @@ class AuthHelper
      *
      * @return string
      */
-    public static function getAccessToken()
+    public static function getAccessToken(&$config)
     {
-        $config = ShopifySDK::$config;
-
         if(!isset($config['SharedSecret']) || !isset($config['ApiKey'])) {
             throw new SdkException("SharedSecret and ApiKey are required for getting access token. Please check SDK configuration!");
         }

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -39,6 +39,8 @@ abstract class ShopifyResource
      */
     protected $resourceUrl;
 
+    protected $config;
+
     /**
      * Key of the API Resource which is used to fetch data from request responses
      *
@@ -108,16 +110,16 @@ abstract class ShopifyResource
     /**
      * Create a new Shopify API resource instance.
      *
+     * @param array $config
      * @param integer $id
      * @param string $parentResourceUrl
      *
      * @throws SdkException if Either AccessToken or ApiKey+Password Combination is not found in configuration
      */
-    public function __construct($id = null, $parentResourceUrl = '')
+    public function __construct($config, $id = null, $parentResourceUrl = '')
     {
+        $this->config = $config;
         $this->id = $id;
-
-        $config = ShopifySDK::$config;
 
         $this->resourceUrl = ($parentResourceUrl ? $parentResourceUrl . '/' :  $config['AdminUrl']) . $this->getResourcePath() . ($this->id ? '/' . $this->id : '');
 
@@ -181,7 +183,7 @@ abstract class ShopifyResource
             $resourceID = !empty($arguments) ? $arguments[0] : null;
 
 
-            $api = new $childClass($resourceID, $this->resourceUrl);
+            $api = new $childClass($this->config, $resourceID, $this->resourceUrl);
 
             return $api;
         } else {

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -147,7 +147,7 @@ class ShopifySDK
      *
      * @var array
      */
-    public static $config = array();
+    public $config = array();
 
     /**
      * List of available resources which can be called from this client
@@ -223,8 +223,8 @@ class ShopifySDK
     public function __construct($config = array())
     {
         if(!empty($config)) {
-            ShopifySDK::$config = $config;
-            ShopifySDK::setAdminUrl();
+            $this->config = $config;
+            $this->setAdminUrl();
         }
     }
 
@@ -271,7 +271,7 @@ class ShopifySDK
         $resourceID = !empty($arguments) ? $arguments[0] : null;
 
         //Initiate the resource object
-        $resource = new $resourceClassName($resourceID);
+        $resource = new $resourceClassName( $this->config, $resourceID);
 
         return $resource;
     }
@@ -283,15 +283,15 @@ class ShopifySDK
      *
      * @return ShopifySDK
      */
-    public static function config($config)
+    public function config($config)
     {
         foreach ($config as $key => $value) {
-            self::$config[$key] = $value;
+            $this->config[$key] = $value;
         }
 
         //Re-set the admin url if shop url is changed
         if(isset($config['ShopUrl'])) {
-            self::setAdminUrl();
+            $this->setAdminUrl();
         }
 
         //If want to keep more wait time than .5 seconds for each call
@@ -307,22 +307,22 @@ class ShopifySDK
      *
      * @return string
      */
-    public static function setAdminUrl()
+    public function setAdminUrl()
     {
-        $shopUrl = self::$config['ShopUrl'];
+        $shopUrl = $this->config['ShopUrl'];
 
         //Remove https:// and trailing slash (if provided)
         $shopUrl = preg_replace('#^https?://|/$#', '', $shopUrl);
 
-        if(isset(self::$config['ApiKey']) && isset(self::$config['Password'])) {
-            $apiKey = self::$config['ApiKey'];
-            $apiPassword = self::$config['Password'];
+        if(isset($this->config['ApiKey']) && isset($this->config['Password'])) {
+            $apiKey = $this->config['ApiKey'];
+            $apiPassword = $this->config['Password'];
             $adminUrl = "https://$apiKey:$apiPassword@$shopUrl/admin/";
         } else {
             $adminUrl = "https://$shopUrl/admin/";
         }
 
-        self::$config['AdminUrl'] = $adminUrl;
+        $this->config['AdminUrl'] = $adminUrl;
 
         return $adminUrl;
     }
@@ -332,8 +332,8 @@ class ShopifySDK
      *
      * @return string
      */
-    public static function getAdminUrl() {
-        return self::$config['AdminUrl'];
+    public function getAdminUrl() {
+        return $this->config['AdminUrl'];
     }
 
     /**


### PR DESCRIPTION
Using static properties for configs means that you can never initialize
more than one SDK object at a time.

closes #72 and #61