### PR TITLE
Add parameter $variables to the GraphQL::post()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "type": "library",
     "require": {
         "php": ">=5.6",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "license": "Apache-2.0",
     "authors": [

--- a/lib/GraphQL.php
+++ b/lib/GraphQL.php
@@ -30,16 +30,17 @@ class GraphQL extends ShopifyResource
      * @param string $graphQL A valid GraphQL String. @see https://help.shopify.com/en/api/graphql-admin-api/graphiql-builder GraphiQL builder - you can build your graphql string from here.
      * @param string $url
      * @param bool $wrapData
+     * @param array|null $variables
      *
      * @uses HttpRequestGraphQL::post() to send the HTTP request
      *
      * @return array
      */
-    public function post($graphQL, $url = null, $wrapData = false)
+    public function post($graphQL, $url = null, $wrapData = false, $variables = null)
     {
         if (!$url) $url = $this->generateUrl();
 
-        $response = HttpRequestGraphQL::post($url, $graphQL, $this->httpHeaders);
+        $response = HttpRequestGraphQL::post($url, $graphQL, $this->httpHeaders, $variables);
 
         return $this->processResponse($response);
     }

--- a/lib/HttpRequestGraphQL.php
+++ b/lib/HttpRequestGraphQL.php
@@ -23,14 +23,15 @@ class HttpRequestGraphQL extends HttpRequestJson
     /**
      * Prepare the data and request headers before making the call
      *
-     * @param mixed $data
      * @param array $httpHeaders
+     * @param mixed $data
+     * @param array|null $variables
      *
      * @return void
      *
      * @throws SdkException if $data is not a string
      */
-    protected static function prepareRequest($httpHeaders = array(), $data = array())
+    protected static function prepareRequest($httpHeaders = array(), $data = array(), $variables = null)
     {
 
         if (is_string($data)) {
@@ -44,8 +45,13 @@ class HttpRequestGraphQL extends HttpRequestJson
         }
 
         self::$httpHeaders = $httpHeaders;
-        self::$httpHeaders['Content-type'] = 'application/graphql';
 
+        if (is_array($variables)) {
+            self::$postDataGraphQL = json_encode(['query' => $data, 'variables' => $variables]);
+            self::$httpHeaders['Content-type'] = 'application/json';
+        } else {
+            self::$httpHeaders['Content-type'] = 'application/graphql';
+        }
     }
 
     /**
@@ -54,12 +60,13 @@ class HttpRequestGraphQL extends HttpRequestJson
      * @param string $url
      * @param mixed $data
      * @param array $httpHeaders
+     * @param array|null $variables
      *
      * @return string
      */
-    public static function post($url, $data, $httpHeaders = array())
+    public static function post($url, $data, $httpHeaders = array(), $variables = null)
     {
-        self::prepareRequest($httpHeaders, $data);
+        self::prepareRequest($httpHeaders, $data, $variables);
 
         $response = CurlRequest::post($url, self::$postDataGraphQL, self::$httpHeaders);
 

--- a/lib/HttpRequestJson.php
+++ b/lib/HttpRequestJson.php
@@ -38,8 +38,8 @@ class HttpRequestJson
     /**
      * Prepare the data and request headers before making the call
      *
-     * @param array $dataArray
      * @param array $httpHeaders
+     * @param array $dataArray
      *
      * @return void
      */


### PR DESCRIPTION
Shopify API supports passing graphql-query with variables as separate field (https://help.shopify.com/en/api/getting-started/shopify-and-graphql/variables#variables-in-curl), but here was no options to do that.

I've added new parameter to `GraphQL::post()` and done neccessary changes in `HttpRequestGraphQL::prepareRequest()` to use correct `Content-type` header.