### PR TITLE
Added last http code as exception code

### DIFF
--- a/lib/GraphQL.php
+++ b/lib/GraphQL.php
@@ -11,6 +11,8 @@
 namespace PHPShopify;
 
 
+use PHPShopify\Exception\ApiException;
+use PHPShopify\Exception\CurlException;
 use PHPShopify\Exception\SdkException;
 
 class GraphQL extends ShopifyResource
@@ -33,6 +35,8 @@ class GraphQL extends ShopifyResource
      * @param array|null $variables
      *
      * @uses HttpRequestGraphQL::post() to send the HTTP request
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
      *
      * @return array
      */
@@ -47,6 +51,7 @@ class GraphQL extends ShopifyResource
 
     /**
      * @inheritdoc
+     * @throws SdkException
      */
     public function get($urlParams = array(), $url = null, $dataKey = null)
     {
@@ -55,6 +60,7 @@ class GraphQL extends ShopifyResource
 
     /**
      * @inheritdoc
+     * @throws SdkException
      */
     public function put($dataArray, $url = null, $wrapData = true)
     {
@@ -63,6 +69,7 @@ class GraphQL extends ShopifyResource
 
     /**
      * @inheritdoc
+     * @throws SdkException
      */
     public function delete($urlParams = array(), $url = null)
     {

--- a/lib/HttpRequestJson.php
+++ b/lib/HttpRequestJson.php
@@ -62,7 +62,7 @@ class HttpRequestJson
      * @param string $url
      * @param array $httpHeaders
      *
-     * @return string
+     * @return array
      */
     public static function get($url, $httpHeaders = array())
     {
@@ -80,7 +80,7 @@ class HttpRequestJson
      * @param array $dataArray
      * @param array $httpHeaders
      *
-     * @return string
+     * @return array
      */
     public static function post($url, $dataArray, $httpHeaders = array())
     {
@@ -98,7 +98,7 @@ class HttpRequestJson
      * @param array $dataArray
      * @param array $httpHeaders
      *
-     * @return string
+     * @return array
      */
     public static function put($url, $dataArray, $httpHeaders = array())
     {
@@ -115,7 +115,7 @@ class HttpRequestJson
      * @param string $url
      * @param array $httpHeaders
      *
-     * @return string
+     * @return array
      */
     public static function delete($url, $httpHeaders = array())
     {

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -302,6 +302,9 @@ abstract class ShopifyResource
      *
      * @uses HttpRequestJson::get() to send the HTTP request
      *
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
+     *
      * @return array
      */
     public function get($urlParams = array(), $url = null, $dataKey = null)
@@ -320,6 +323,10 @@ abstract class ShopifyResource
      * Get count for the number of resources available
      *
      * @param array $urlParams Check Shopify API reference of the specific resource for the list of URL parameters
+     *
+     * @throws SdkException
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
      *
      * @return integer
      */
@@ -340,6 +347,8 @@ abstract class ShopifyResource
      * @param mixed $query
      *
      * @throws SdkException if search is not enabled for the resouce
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
      *
      * @return array
      */
@@ -365,6 +374,9 @@ abstract class ShopifyResource
      *
      * @uses HttpRequestJson::post() to send the HTTP request
      *
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
+     *
      * @return array
      */
     public function post($dataArray, $url = null, $wrapData = true)
@@ -387,6 +399,9 @@ abstract class ShopifyResource
      *
      * @uses HttpRequestJson::put() to send the HTTP request
      *
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
+     *
      * @return array
      */
     public function put($dataArray, $url = null, $wrapData = true)
@@ -408,6 +423,9 @@ abstract class ShopifyResource
      * @param string $url
      *
      * @uses HttpRequestJson::delete() to send the HTTP request
+     *
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
      *
      * @return array an empty array will be returned if the request is successfully completed
      */

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -492,8 +492,8 @@ abstract class ShopifyResource
 
         if (isset($responseArray['errors'])) {
             $message = $this->castString($responseArray['errors']);
-
-            throw new ApiException($message);
+z
+            throw new ApiException($message, CurlRequest::$lastHttpCode);
         }
 
         if ($dataKey && isset($responseArray[$dataKey])) {

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -492,7 +492,7 @@ abstract class ShopifyResource
 
         if (isset($responseArray['errors'])) {
             $message = $this->castString($responseArray['errors']);
-z
+
             throw new ApiException($message, CurlRequest::$lastHttpCode);
         }
 


### PR DESCRIPTION
Shopify has a really good policy regarding errors and error codes described here: https://help.shopify.com/en/api/getting-started/response-status-codes (Pretty sure some of the contributors read it since 429 is mentioned in code).

The problem is that the errors ar thrown without the code. That in turn forces ppl to keep using stuff like stripos($response, '[API] Invalid API key or access token') to be able to catch exceptions and treat them. This is results in unnecessary maintenance (especially if for some reason shopify decide to change a message text). Another option would be to call the CurlRequest::$lastHttpCode from outside the php-shopify code, but that would couple the lib into the project and I don't think I need to mention why that is bad :).

I added the last http response code as an error code.

Also (I didn't treat this here but it is a problem), having the $lastHttpCode as static on curl may result in resource races with wrong outcome (unless I'm missing someting here? don't think so but hope so). I plan on adding an issue with that if that's ok with you, and making another pull request to resolve that.