### PR TITLE
Bug solved for previous link in ShopifyResounce

### DIFF
--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -551,7 +551,7 @@ abstract class ShopifyResource
 
     public function getLinks($responseHeaders){
         $this->nextLink = $this->getLink($responseHeaders,'next');
-        $this->prevLink = $this->getLink($responseHeaders,'prev');
+        $this->prevLink = $this->getLink($responseHeaders,'previous');
     }
 
     public function getLink($responseHeaders, $type='next'){
@@ -562,7 +562,6 @@ abstract class ShopifyResource
         }
 
         if(!empty($responseHeaders['link'])) {
-            var_dump($responseHeaders['link']);
             if (stristr($responseHeaders['link'], '; rel="'.$type.'"') > -1) {
                 $headerLinks = explode(',', $responseHeaders['link']);
                 foreach ($headerLinks as $headerLink) {


### PR DESCRIPTION
The previous link was not getting assigned to `prevLink` property in the `ShopifyResource` class.
Also, var_dump statement removed from `getLink` Method in `ShopifyResource` class.