### PR TITLE
Make sure header keys are always lowercase

### DIFF
--- a/lib/CurlResponse.php
+++ b/lib/CurlResponse.php
@@ -27,7 +27,8 @@ class CurlResponse
             foreach (\explode("\r\n", $headers) as $header) {
                 $pair = \explode(': ', $header, 2);
                 if (isset($pair[1])) {
-                    $this->headers[$pair[0]] = $pair[1];
+                    $headerKey = strtolower($pair[0]);
+                    $this->headers[$headerKey] = $pair[1];
                 }
             }
         } else {


### PR DESCRIPTION
Since http2 header field names must be lowercase ( https://httpwg.org/specs/rfc7540.html#HttpHeaders ) but if curl uses a lower http version the field names are in mixed case. I noticed as on our live system the prev. and next links couldn't be found as with http1.1 they're in the field `Link` instead of `link`. So it makes sense to always make sure they're lower case for consistency.