### PR TITLE
price rule endpoint supports count

### DIFF
--- a/lib/PriceRule.php
+++ b/lib/PriceRule.php
@@ -29,11 +29,6 @@ class PriceRule extends ShopifyResource
     /**
      * @inheritDoc
      */
-    public $countEnabled = false;
-
-    /**
-     * @inheritDoc
-     */
     protected $childResource = array(
         'DiscountCode'
     );


### PR DESCRIPTION
The shopify API supports the count resource on the pricerule endpoint: https://shopify.dev/docs/admin-api/rest/reference/discounts/pricerule?api[version]=2020-04#count-2020-04