### PR TITLE
Added ShopifyPayment Dispute resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Some resources are available directly, some resources are only available through
 - [Shop](https://help.shopify.com/api/reference/shop) _(read only)_
 - [SmartCollection](https://help.shopify.com/api/reference/smartcollection)
 - SmartCollection -> [Event](https://help.shopify.com/api/reference/event/)
+- [ShopifyPayment](https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/)
+- ShopifyPayment -> [Dispute](https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/dispute/) _(read only)_
 - [Theme](https://help.shopify.com/api/reference/theme)
 - Theme -> [Asset](https://help.shopify.com/api/reference/asset/)
 - [User](https://help.shopify.com/api/reference/user) _(read only, Shopify Plus Only)_

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Victor Kislichenko <v.kislichenko@gmail.com>
+ * Created at 01/06/2020 16:45 AM UTC+03:00
+ *
+ * @see https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/dispute Shopify API Reference for Dispute
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * ShopifyPayment -> Child Resources
+ * --------------------------------------------------------------------------
+ * @property-read ShopifyResource $DiscountCode
+ *
+ * @method ShopifyResource DiscountCode(integer $id = null)
+ *
+ */
+class Dispute extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    public $resourceKey = 'dispute';
+
+
+}

--- a/lib/ShopifyPayment.php
+++ b/lib/ShopifyPayment.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Victor Kislichenko <v.kislichenko@gmail.com>
+ * Created at 01/06/2020 16:45 AM UTC+03:00
+ *
+ * @see https://shopify.dev/docs/admin-api/rest/reference/shopify_payments Shopify API Reference for ShopifyPayment
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * ShopifyPayment -> Child Resources
+ * --------------------------------------------------------------------------
+ * @property-read ShopifyResource $Dispute
+ *
+ * @method ShopifyResource Dispute(integer $id = null)
+ *
+ */
+class ShopifyPayment extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    public $resourceKey = 'shopify_payment';
+
+    /**
+     * @inheritDoc
+     */
+    protected $childResource = array(
+        'Dispute'
+    );
+}

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -530,7 +530,7 @@ abstract class ShopifyResource
             $httpCode = CurlRequest::$lastHttpCode;
 
             if ($httpCode != null && $httpCode != $httpOK && $httpCode != $httpCreated && $httpCode != $httpDeleted) {
-                throw new Exception\CurlException("Request failed with HTTP Code $httpCode.");
+                throw new Exception\CurlException("Request failed with HTTP Code $httpCode.", $httpCode);
             }
         }
 

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -104,6 +104,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read ShippingZone $ShippingZone
  * @property-read Shop $Shop
  * @property-read SmartCollection $SmartCollection
+ * @property-read ShopifyPayment $ShopifyPayment
  * @property-read Theme $Theme
  * @property-read User $User
  * @property-read Webhook $Webhook
@@ -196,6 +197,7 @@ class ShopifySDK
         'ShippingZone',
         'Shop',
         'SmartCollection',
+        'ShopifyPayment',
         'Theme',
         'User',
         'Webhook',


### PR DESCRIPTION
- Added Resource for [ShopifyPayments Dispute](https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/dispute?api[version]=2020-01)
- Added $httpCode pass-thru when throwing CurlException (required as dispute endpoint responds with 404 where there are no dispute in store)