### PR TITLE
Add Shopify API headers as a config to the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,15 @@ The custom methods are specific to some resources which may not be available for
     - [current()](https://help.shopify.com/api/reference/user#current)
     Get the current logged-in user
 
+### Shopify API features headers
+To send `X-Shopify-Api-Features` headers while using the SDK, you can use the following:
+
+```
+$config['ShopifyApiFeatures'] = ['include-presentment-prices'];
+$shopify = new PHPShopify\ShopifySDK($config);
+```
+
+
 ## Reference
 - [Shopify API Reference](https://help.shopify.com/api/reference/)
 

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -149,6 +149,12 @@ abstract class ShopifyResource
         } elseif (!isset($config['ApiKey']) || !isset($config['Password'])) {
             throw new SdkException("Either AccessToken or ApiKey+Password Combination (in case of private API) is required to access the resources. Please check SDK configuration!");
         }
+
+        if (isset($config['ShopifyApiFeatures'])) {
+            foreach($config['ShopifyApiFeatures'] as $apiFeature) {
+                $this->httpHeaders['X-Shopify-Api-Features'] = $apiFeature;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

Shopify now asks for some headers for certain new features (i.e: price presentment for Product Variant https://shopify.dev/docs/admin-api/rest/reference/products/product-variant?api[version]=2020-04 ) I'm guessing that they will add more features that could be activated using that HTTP header.

I have added this in my app since I needed it. Not sure if others would find this useful too?