### PR TITLE
Fix bug introduced by #143 by lowercasing key in getHeader

### DIFF
--- a/lib/CurlResponse.php
+++ b/lib/CurlResponse.php
@@ -53,6 +53,7 @@ class CurlResponse
      */
     public function getHeader($key)
     {
+        $key = strtolower($key);
         return isset($this->headers[$key]) ? $this->headers[$key] : null;
     }
 


### PR DESCRIPTION
As discussed, #143 lowercases all headers in CurlResponse. This is a breaking change which stops the following from working:

https://github.com/phpclassic/php-shopify/blob/a233b8d6e22e651402ef2e440b9433aa704146b8/lib/CurlRequest.php#L163

This PR lowercases the given key in the CurlResponse::getHeader method before checking if it is set.