### PR TITLE
Use Retry-After header as value to sleep for before retrying request

### DIFF
--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -166,7 +166,13 @@ class CurlRequest
                 throw new ResourceRateLimitException($response->getBody());
             }
 
-            usleep(500000);
+            $retryAfter = $response->getHeader('Retry-After');
+
+            if ($retryAfter === null) {
+                break;
+            }
+
+            sleep((float)$retryAfter);
         }
 
         if (curl_errno($ch)) {


### PR DESCRIPTION
This PR uses the `Retry-After` header provided from Shopify in a 429 Too Many Requests response as the amount of time to sleep before retrying the request.

When using the hard-coded value of 0.5 seconds an infinite loop can occur because if the Retry-After value is higher than this, Shopify will keep rejecting the request with a 429 error.

This PR needs #183 to be merged to work properly.