### PR TITLE
Support DiscountCode batch Action

### DIFF
--- a/lib/Batch.php
+++ b/lib/Batch.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see https://help.shopify.com/api/reference/discounts/discountcode Shopify API Reference for PriceRule
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * DiscountCode -> Batch action
+ * --------------------------------------------------------------------------
+ *
+ */
+
+class Batch extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'batch';
+
+    protected function getResourcePath()
+    {
+        return $this->resourceKey;
+    }
+
+    protected function wrapData($dataArray, $dataKey = null)
+    {
+        return ['discount_codes' => $dataArray];
+    }
+
+}

--- a/lib/PriceRule.php
+++ b/lib/PriceRule.php
@@ -17,6 +17,7 @@ namespace PHPShopify;
  * @property-read ShopifyResource $DiscountCode
  *
  * @method ShopifyResource DiscountCode(integer $id = null)
+ * @method ShopifyResource Batch()
  *
  */
 class PriceRule extends ShopifyResource
@@ -30,6 +31,7 @@ class PriceRule extends ShopifyResource
      * @inheritDoc
      */
     protected $childResource = array(
-        'DiscountCode'
+        'DiscountCode',
+        'Batch',
     );
 }


### PR DESCRIPTION
Add support for creating DiscountCodes on a PriceRule via the Batch action:

```php
$api->PriceRule($priceRuleId)->Batch()->post([
    ['code' => 'ABC'],
    ['code' => 'BCD'],
    ['code' => 'CDE'],
])
```