### PR TITLE
calculate() takes an optional array as a parameter.

### DIFF
--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -14,7 +14,7 @@ namespace PHPShopify;
  * --------------------------------------------------------------------------
  * Refund -> Custom actions
  * --------------------------------------------------------------------------
- * @method array calculate()      Calculate a Refund.
+ * @method array calculate(array $calculation = null)      Calculate a Refund.
  *
  */
 class Refund extends ShopifyResource


### PR DESCRIPTION
When I pass in the array, I get a warning in my IDE since it's not defined in this class. So I updated the definition.