### PR TITLE
Added the Cart Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,8 @@ Some resources are available directly, some resources are only available through
 - Blog -> Article -> [Metafield](https://help.shopify.com/api/reference/metafield)
 - Blog -> [Event](https://help.shopify.com/api/reference/event/)
 - Blog -> [Metafield](https://help.shopify.com/api/reference/metafield)
-- [CarrierService](https://help.shopify.com/api/reference/carrierservice/)
+- [CarrierService](https://help.shopify.com/api/reference/carrierservice/)-
+- [Cart](https://shopify.dev/docs/themes/ajax-api/reference/cart) (read only)
 - [Collect](https://help.shopify.com/api/reference/collect/)
 - [Comment](https://help.shopify.com/api/reference/comment/)
 - Comment -> [Event](https://help.shopify.com/api/reference/event/)

--- a/lib/Cart.php
+++ b/lib/Cart.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PHPShopify;
+
+/* @see https://shopify.dev/docs/themes/ajax-api/reference/cart */
+use PHPShopify\ShopifyResource;
+
+class Cart extends ShopifyResource {
+
+     /**
+     * @inheritDoc
+     */
+    protected $resourceKey ='cart';
+
+     /**
+     * @inheritDoc
+     */
+    public $searchEnabled = false;
+
+     /**
+     * @inheritDoc
+     */
+    public $readOnly = true;
+}

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -71,6 +71,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read ApplicationCharge $ApplicationCharge
  * @property-read Blog $Blog
  * @property-read CarrierService $CarrierService
+ * @property-read Cart $Cart
  * @property-read Collect $Collect
  * @property-read Collection $Collection
  * @property-read Comment $Comment
@@ -115,6 +116,7 @@ use PHPShopify\Exception\SdkException;
  * @method ApplicationCharge ApplicationCharge(integer $id = null)
  * @method Blog Blog(integer $id = null)
  * @method CarrierService CarrierService(integer $id = null)
+ * @method Cart Cart(string $cart_token = null)
  * @method Collect Collect(integer $id = null)
  * @method Collection Collection(integer $id = null)
  * @method Comment Comment(integer $id = null)
@@ -167,6 +169,7 @@ class ShopifySDK
         'ApplicationCharge',
         'Blog',
         'CarrierService',
+        'Cart',
         'Collect',
         'Collection',
         'Comment',


### PR DESCRIPTION
The `Cart` resource is read only, where you can provide the cart_token to retrieve the Shopify cart object.
Example: `$shopify->Cart('1d19a32178501c44ef2223d73c54d16d')->get()`

Example Response: 
```
{
  "token": "1d19a32178501c44ef2223d73c54d16d",
  "note": null,
  "attributes": {},
  "total_price": 0,
  "total_weight": 0,
  "item_count": 0,
  "items": [],
  "requires_shipping": false,
  "currency": "CAD"
}
```

You can retrieve the cart token on your website by using the following javascript snippet: 
`var cart_token = (document.cookie.match('(^|; )cart=([^;]*)') || 0)[2];`

I'm sorry I didn't provide any tests because this is really a shop specific resource request.  I did test the cart resource using my own shop and credentials and it worked just fine. 

I'm not completely versed in the library and might be missing some class properties that would be needed to prevent the user from using the update or post methods.  Please let me know if there are any additional changes I need to have this merged in to project.  

Thank you!