### PR TITLE
Allowing Curl to follow location and prevent 302 shopify response APi

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Some resources are available directly, some resources are only available through
 - [Shop](https://help.shopify.com/api/reference/shop) _(read only)_
 - [SmartCollection](https://help.shopify.com/api/reference/smartcollection)
 - SmartCollection -> [Event](https://help.shopify.com/api/reference/event/)
+- [ShopifyPayment](https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/)
+- ShopifyPayment -> [Dispute](https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/dispute/) _(read only)_
 - [Theme](https://help.shopify.com/api/reference/theme)
 - Theme -> [Asset](https://help.shopify.com/api/reference/asset/)
 - [User](https://help.shopify.com/api/reference/user) _(read only, Shopify Plus Only)_

--- a/README.md
+++ b/README.md
@@ -485,6 +485,15 @@ The custom methods are specific to some resources which may not be available for
     - [current()](https://help.shopify.com/api/reference/user#current)
     Get the current logged-in user
 
+### Shopify API features headers
+To send `X-Shopify-Api-Features` headers while using the SDK, you can use the following:
+
+```
+$config['ShopifyApiFeatures'] = ['include-presentment-prices'];
+$shopify = new PHPShopify\ShopifySDK($config);
+```
+
+
 ## Reference
 - [Shopify API Reference](https://help.shopify.com/api/reference/)
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ $shopify->Order($orderID)->put($updateInfo);
 ```php
 $webHookID = 453487303;
 
-$shopify->Webhook($webHookID)->delete());
+$shopify->Webhook($webHookID)->delete();
 ```
 
 

--- a/lib/Balance.php
+++ b/lib/Balance.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Robert Jacobson <rjacobson@thexroadz.com>
+ * @author Matthew Crigger <mcrigger@thexroadz.com>
+ *
+ * @see https://help.shopify.com/en/api/reference/shopify_payments/balance Shopify API Reference for Shopify Payment Balance
+ */
+
+namespace PHPShopify;
+
+/**
+ * --------------------------------------------------------------------------
+ * ShopifyPayment -> Child Resources
+ * --------------------------------------------------------------------------
+ *
+ *
+ */
+class Balance extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'balance';
+
+    /**
+     * Get the pluralized version of the resource key
+     *
+     * Normally its the same as $resourceKey appended with 's', when it's different, the specific resource class will override this function
+     *
+     * @return string
+     */
+    protected function pluralizeKey()
+    {
+        return $this->resourceKey;
+    }
+
+    /**
+     * If the resource is read only. (No POST / PUT / DELETE actions)
+     *
+     * @var boolean
+     */
+    public $readOnly = true;
+
+    /**
+     * @inheritDoc
+     */
+    protected $childResource = array(
+        'Transactions'
+    );
+}

--- a/lib/Batch.php
+++ b/lib/Batch.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see https://help.shopify.com/api/reference/discounts/discountcode Shopify API Reference for PriceRule
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * DiscountCode -> Batch action
+ * --------------------------------------------------------------------------
+ *
+ */
+
+class Batch extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'batch';
+
+    protected function getResourcePath()
+    {
+        return $this->resourceKey;
+    }
+
+    protected function wrapData($dataArray, $dataKey = null)
+    {
+        return ['discount_codes' => $dataArray];
+    }
+
+}

--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -166,7 +166,13 @@ class CurlRequest
                 throw new ResourceRateLimitException($response->getBody());
             }
 
-            usleep(500000);
+            $retryAfter = $response->getHeader('Retry-After');
+
+            if ($retryAfter === null) {
+                break;
+            }
+
+            sleep((float)$retryAfter);
         }
 
         if (curl_errno($ch)) {

--- a/lib/CurlResponse.php
+++ b/lib/CurlResponse.php
@@ -53,6 +53,7 @@ class CurlResponse
      */
     public function getHeader($key)
     {
+        $key = strtolower($key);
         return isset($this->headers[$key]) ? $this->headers[$key] : null;
     }
 

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -22,7 +22,7 @@ namespace PHPShopify;
  * --------------------------------------------------------------------------
  * Customer -> Custom actions
  * --------------------------------------------------------------------------
- * @method array search()      Search for customers matching supplied query
+ * @method array search(string $query = '')      Search for customers matching supplied query
  */
 class Customer extends ShopifyResource
 {

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -60,4 +60,21 @@ class Customer extends ShopifyResource
 
         return $this->post($dataArray, $url, false);
     }
+
+    /**
+     * Create account_activation_link for customer.
+     *
+     * @param array $customer_id
+     *
+     * @return array
+     */
+    public function account_activation_url($customer_id = 0)
+    {
+        if (!(int)$customer_id > 0) {
+            return false;
+        }
+
+        $url = $this->generateUrl(array(), $customer_id.'/account_activation_url');
+        return $this->post(array(), $url, false);
+    }
 }

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Victor Kislichenko <v.kislichenko@gmail.com>
+ * Created at 01/06/2020 16:45 AM UTC+03:00
+ *
+ * @see https://shopify.dev/docs/admin-api/rest/reference/shopify_payments/dispute Shopify API Reference for Dispute
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * ShopifyPayment -> Child Resources
+ * --------------------------------------------------------------------------
+ * @property-read ShopifyResource $DiscountCode
+ *
+ * @method ShopifyResource DiscountCode(integer $id = null)
+ *
+ */
+class Dispute extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    public $resourceKey = 'dispute';
+
+
+}

--- a/lib/Payouts.php
+++ b/lib/Payouts.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Robert Jacobson <rjacobson@thexroadz.com>
+ * @author Matthew Crigger <mcrigger@thexroadz.com>
+ *
+ * @see https://help.shopify.com/en/api/reference/shopify_payments/payout Shopify API Reference for Shopify Payment Payouts
+ */
+
+namespace PHPShopify;
+
+/**
+ * --------------------------------------------------------------------------
+ * ShopifyPayment -> Child Resources
+ * --------------------------------------------------------------------------
+ *
+ *
+ */
+class Payouts extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'payout';
+}

--- a/lib/PriceRule.php
+++ b/lib/PriceRule.php
@@ -29,11 +29,6 @@ class PriceRule extends ShopifyResource
     /**
      * @inheritDoc
      */
-    public $countEnabled = false;
-
-    /**
-     * @inheritDoc
-     */
     protected $childResource = array(
         'DiscountCode'
     );

--- a/lib/PriceRule.php
+++ b/lib/PriceRule.php
@@ -17,6 +17,7 @@ namespace PHPShopify;
  * @property-read ShopifyResource $DiscountCode
  *
  * @method ShopifyResource DiscountCode(integer $id = null)
+ * @method ShopifyResource Batch()
  *
  */
 class PriceRule extends ShopifyResource
@@ -30,6 +31,7 @@ class PriceRule extends ShopifyResource
      * @inheritDoc
      */
     protected $childResource = array(
-        'DiscountCode'
+        'DiscountCode',
+        'Batch',
     );
 }

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -14,7 +14,7 @@ namespace PHPShopify;
  * --------------------------------------------------------------------------
  * Refund -> Custom actions
  * --------------------------------------------------------------------------
- * @method array calculate()      Calculate a Refund.
+ * @method array calculate(array $calculation = null)      Calculate a Refund.
  *
  */
 class Refund extends ShopifyResource

--- a/lib/ShopifyPayment.php
+++ b/lib/ShopifyPayment.php
@@ -18,6 +18,15 @@ namespace PHPShopify;
  *
  * @method ShopifyResource Dispute(integer $id = null)
  *
+ * @property-read ShopifyResource $Balance
+ *
+ * @method ShopifyResource Balance(integer $id = null)
+ *
+ * @property-read ShopifyResource $Payouts
+ *
+ * @method ShopifyResource Payouts(integer $id = null)
+ *
+
  */
 class ShopifyPayment extends ShopifyResource
 {
@@ -27,9 +36,18 @@ class ShopifyPayment extends ShopifyResource
     public $resourceKey = 'shopify_payment';
 
     /**
+     * If the resource is read only. (No POST / PUT / DELETE actions)
+     *
+     * @var boolean
+     */
+    public $readOnly = true;
+
+    /**
      * @inheritDoc
      */
     protected $childResource = array(
-        'Dispute'
+        'Balance',
+        'Dispute',
+        'Payouts',
     );
 }

--- a/lib/ShopifyPayment.php
+++ b/lib/ShopifyPayment.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Victor Kislichenko <v.kislichenko@gmail.com>
+ * Created at 01/06/2020 16:45 AM UTC+03:00
+ *
+ * @see https://shopify.dev/docs/admin-api/rest/reference/shopify_payments Shopify API Reference for ShopifyPayment
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * ShopifyPayment -> Child Resources
+ * --------------------------------------------------------------------------
+ * @property-read ShopifyResource $Dispute
+ *
+ * @method ShopifyResource Dispute(integer $id = null)
+ *
+ */
+class ShopifyPayment extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    public $resourceKey = 'shopify_payment';
+
+    /**
+     * @inheritDoc
+     */
+    protected $childResource = array(
+        'Dispute'
+    );
+}

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -530,7 +530,7 @@ abstract class ShopifyResource
             $httpCode = CurlRequest::$lastHttpCode;
 
             if ($httpCode != null && $httpCode != $httpOK && $httpCode != $httpCreated && $httpCode != $httpDeleted) {
-                throw new Exception\CurlException("Request failed with HTTP Code $httpCode.");
+                throw new Exception\CurlException("Request failed with HTTP Code $httpCode.", $httpCode);
             }
         }
 

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -149,6 +149,12 @@ abstract class ShopifyResource
         } elseif (!isset($config['ApiKey']) || !isset($config['Password'])) {
             throw new SdkException("Either AccessToken or ApiKey+Password Combination (in case of private API) is required to access the resources. Please check SDK configuration!");
         }
+
+        if (isset($config['ShopifyApiFeatures'])) {
+            foreach($config['ShopifyApiFeatures'] as $apiFeature) {
+                $this->httpHeaders['X-Shopify-Api-Features'] = $apiFeature;
+            }
+        }
     }
 
     /**

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -546,6 +546,11 @@ abstract class ShopifyResource
         if (isset($responseArray['errors'])) {
             $message = $this->castString($responseArray['errors']);
 
+            //check account already enabled or not
+            if($message=='account already enabled'){
+                return array('account_activation_url'=>false);
+            }
+            
             throw new ApiException($message, CurlRequest::$lastHttpCode);
         }
 

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -105,6 +105,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read Shop $Shop
  * @property-read SmartCollection $SmartCollection
  * @property-read ShopifyPayment $ShopifyPayment
+ * @property-read TenderTransaction $TenderTransaction
  * @property-read Theme $Theme
  * @property-read User $User
  * @property-read Webhook $Webhook
@@ -148,6 +149,7 @@ use PHPShopify\Exception\SdkException;
  * @method Shop Shop(integer $id = null)
  * @method ShopifyPayment ShopifyPayment()
  * @method SmartCollection SmartCollection(integer $id = null)
+ * @method TenderTransaction TenderTransaction()
  * @method Theme Theme(int $id = null)
  * @method User User(integer $id = null)
  * @method Webhook Webhook(integer $id = null)
@@ -199,6 +201,7 @@ class ShopifySDK
         'Shop',
         'SmartCollection',
         'ShopifyPayment',
+        'TenderTransaction',
         'Theme',
         'User',
         'Webhook',

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -104,6 +104,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read ShippingZone $ShippingZone
  * @property-read Shop $Shop
  * @property-read SmartCollection $SmartCollection
+ * @property-read ShopifyPayment $ShopifyPayment
  * @property-read Theme $Theme
  * @property-read User $User
  * @property-read Webhook $Webhook
@@ -196,6 +197,7 @@ class ShopifySDK
         'ShippingZone',
         'Shop',
         'SmartCollection',
+        'ShopifyPayment',
         'Theme',
         'User',
         'Webhook',

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -68,6 +68,7 @@ use PHPShopify\Exception\SdkException;
 
 /**
  * @property-read AbandonedCheckout $AbandonedCheckout
+ * @property-read ApplicationCharge $ApplicationCharge
  * @property-read Blog $Blog
  * @property-read CarrierService $CarrierService
  * @property-read Collect $Collect
@@ -81,7 +82,6 @@ use PHPShopify\Exception\SdkException;
  * @property-read Discount $Discount
  * @property-read DiscountCode $DiscountCode
  * @property-read DraftOrder $DraftOrder
- * @property-read PriceRule $PriceRule
  * @property-read Event $Event
  * @property-read FulfillmentService $FulfillmentService
  * @property-read GiftCard $GiftCard
@@ -96,8 +96,10 @@ use PHPShopify\Exception\SdkException;
  * @property-read Product $Product
  * @property-read ProductListing $ProductListing
  * @property-read ProductVariant $ProductVariant
+ * @property-read PriceRule $PriceRule
  * @property-read RecurringApplicationCharge $RecurringApplicationCharge
  * @property-read Redirect $Redirect
+ * @property-read Report $Report
  * @property-read ScriptTag $ScriptTag
  * @property-read ShippingZone $ShippingZone
  * @property-read Shop $Shop
@@ -108,6 +110,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read GraphQL $GraphQL
  *
  * @method AbandonedCheckout AbandonedCheckout(integer $id = null)
+ * @method ApplicationCharge ApplicationCharge(integer $id = null)
  * @method Blog Blog(integer $id = null)
  * @method CarrierService CarrierService(integer $id = null)
  * @method Collect Collect(integer $id = null)
@@ -121,7 +124,6 @@ use PHPShopify\Exception\SdkException;
  * @method Discount Discount(integer $id = null)
  * @method DraftOrder DraftOrder(integer $id = null)
  * @method DiscountCode DiscountCode(integer $id = null)
- * @method PriceRule PriceRule(integer $id = null)
  * @method Event Event(integer $id = null)
  * @method FulfillmentService FulfillmentService(integer $id = null)
  * @method GiftCard GiftCard(integer $id = null)
@@ -136,8 +138,10 @@ use PHPShopify\Exception\SdkException;
  * @method Product Product(integer $id = null)
  * @method ProductListing ProductListing(integer $id = null)
  * @method ProductVariant ProductVariant(integer $id = null)
+ * @method PriceRule PriceRule(integer $id = null)
  * @method RecurringApplicationCharge RecurringApplicationCharge(integer $id = null)
  * @method Redirect Redirect(integer $id = null)
+ * @method Report Report(integer $id = null)
  * @method ScriptTag ScriptTag(integer $id = null)
  * @method ShippingZone ShippingZone(integer $id = null)
  * @method Shop Shop(integer $id = null)

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -146,6 +146,7 @@ use PHPShopify\Exception\SdkException;
  * @method ScriptTag ScriptTag(integer $id = null)
  * @method ShippingZone ShippingZone(integer $id = null)
  * @method Shop Shop(integer $id = null)
+ * @method ShopifyPayment ShopifyPayment()
  * @method SmartCollection SmartCollection(integer $id = null)
  * @method Theme Theme(int $id = null)
  * @method User User(integer $id = null)
@@ -235,16 +236,20 @@ class ShopifySDK
     protected $childResources = array(
         'Article'           => 'Blog',
         'Asset'             => 'Theme',
+        'Balance'           => 'ShopifyPayment',
         'CustomerAddress'   => 'Customer',
+        'Dispute'           => 'ShopifyPayment',
         'Fulfillment'       => 'Order',
         'FulfillmentEvent'  => 'Fulfillment',
         'OrderRisk'         => 'Order',
+        'Payouts'           => 'ShopifyPayment',
         'ProductImage'      => 'Product',
         'ProductVariant'    => 'Product',
         'DiscountCode'      => 'PriceRule',
         'Province'          => 'Country',
         'Refund'            => 'Order',
         'Transaction'       => 'Order',
+        'Transactions'      => 'Balance',
         'UsageCharge'       => 'RecurringApplicationCharge',
     );
 

--- a/lib/TenderTransaction.php
+++ b/lib/TenderTransaction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PHPShopify;
+
+class TenderTransaction extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'tender_transaction';
+
+    /**
+     * If the resource is read only. (No POST / PUT / DELETE actions)
+     *
+     * @var boolean
+     */
+    public $readOnly = true;
+}

--- a/lib/Transactions.php
+++ b/lib/Transactions.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Robert Jacobson <rjacobson@thexroadz.com>
+ * @author Matthew Crigger <mcrigger@thexroadz.com>
+ *
+ * @see https://help.shopify.com/en/api/reference/shopify_payments/transaction Shopify API Reference for Shopify Payment Transactions
+ */
+
+namespace PHPShopify;
+
+
+class Transactions extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'transaction';
+
+    /**
+     * If the resource is read only. (No POST / PUT / DELETE actions)
+     *
+     * @var boolean
+     */
+    public $readOnly = true;
+}


### PR DESCRIPTION
Hi
With my team we encountered a 302 error response due to a client using a real domain instead of .myshopify.com domain.

So we have understood that curl needed to follow location.
For change look at tools/shopifysdk/phpclassic/php-shopify/lib/CurlRequest.php row 56

Add this line 
`curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);`