### PR TITLE
Throw an exception if the access token request failed

### DIFF
--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -170,6 +170,10 @@ class AuthHelper
 
             $response = HttpRequestJson::post($config['AdminUrl'] . 'oauth/access_token', $data);
 
+            if (CurlRequest::$lastHttpCode >= 400) {
+                throw new SdkException("Invalid request. The shop domain is incorrect or the authorization code has already been used.");
+            }
+
             return isset($response['access_token']) ? $response['access_token'] : null;
         } else {
             throw new SdkException("This request is not initiated from a valid shopify shop!");

--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -171,7 +171,7 @@ class AuthHelper
             $response = HttpRequestJson::post($config['AdminUrl'] . 'oauth/access_token', $data);
 
             if (CurlRequest::$lastHttpCode >= 400) {
-                throw new SdkException('The shop is invalid or the authorization code has already been used.');
+                throw new SdkException("The shop is invalid or the authorization code has already been used.");
             }
 
             return isset($response['access_token']) ? $response['access_token'] : null;

--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -171,7 +171,7 @@ class AuthHelper
             $response = HttpRequestJson::post($config['AdminUrl'] . 'oauth/access_token', $data);
 
             if (CurlRequest::$lastHttpCode >= 400) {
-                throw new SdkException("Invalid request. The shop domain is incorrect or the authorization code has already been used.");
+                throw new SdkException('The shop is invalid or the authorization code has already been used.');
             }
 
             return isset($response['access_token']) ? $response['access_token'] : null;


### PR DESCRIPTION
Rather than returning null if the access token request fails, the `getAccessToken()` method in `AuthHelper.php` should throw an `SdkException` so that when the method is invoked in a try-catch the developer can choose how to act upon a bad request (usually HTTP 400).

This can happen when trying to request an access token twice with the same authorisation code, which can happen if the user installing the Shopify app refreshes the callback route. The user might do this by accident, by using page navigation in their browser or when the developers app crashes on that route. If this does happen, then the developer may choose to redirect them back to Shopify safely, rather than trying to move ahead with using a null access token.