### PR TITLE
Return location header as array if response is 303

### DIFF
--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -531,9 +531,14 @@ abstract class ShopifyResource
             $httpOK = 200; //Request Successful, OK.
             $httpCreated = 201; //Create Successful.
             $httpDeleted = 204; //Delete Successful
+            $httpOther = 303; //See other (headers).
 
             //should be null if any other library used for http calls
             $httpCode = CurlRequest::$lastHttpCode;
+
+            if ($httpCode == $httpOther && array_key_exists('location', self::$lastHttpResponseHeaders)) {
+                return ['location' => self::$lastHttpResponseHeaders['location']];
+            }
 
             if ($httpCode != null && $httpCode != $httpOK && $httpCode != $httpCreated && $httpCode != $httpDeleted) {
                 throw new Exception\CurlException("Request failed with HTTP Code $httpCode.", $httpCode);


### PR DESCRIPTION
A useful fix for endpoints such as discount code lookup, which returns a 303 HTTP status code along with a header indicating the full URI of the discount code on the shop.

See more: https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#lookup-2021-01
