### PR TITLE
Remove query params from current url

### DIFF
--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -28,8 +28,11 @@ class AuthHelper
         else {
             $protocol = 'http';
         }
+        
+        $url = $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        $url = false !== ($qsPos = strpos($url, '?')) ? substr($url, 0, $qsPos) : $url; // remove query params
 
-        return "$protocol://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+        return $url;
     }
 
     /**


### PR DESCRIPTION
When we use one page for authorize and redirect_uri, we have a problem with autogenerated query params, such as hmac and etc.
So Shopify throw an error that redirect_uri is not whitelisted. But we cannot whitelist such url.
I suggest to simply remove these query params from redirect_uri.