### PR TITLE
Adding Fulfillment Order

### DIFF
--- a/lib/FulfillmentOrder.php
+++ b/lib/FulfillmentOrder.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Mark Solly <mark@solly.com.au>
+ * Created at 5/21/21 11:27 AM UTC+10:00
+ *
+ * @see https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillmentorder Shopify API Reference for Fulfillment Order
+ */
+
+namespace PHPShopify;
+
+
+/**
+ * --------------------------------------------------------------------------
+ * FulfillmentOrder -> Child Resources
+ * --------------------------------------------------------------------------
+ *
+ * --------------------------------------------------------------------------
+ * Fulfillment -> Custom actions
+ * --------------------------------------------------------------------------
+ * @method array cancel()     Cancel a fulfillment order
+ * @method array open()       Open a fulfillment order
+ * @method array close()       Close a fulfillment order
+ * @method array move()			Move a fulfilment order to a new location
+ * @method array reschedule()	Reschedule fulfill_at_time of a scheduled fulfillment order
+ *
+ */
+class FulfillmentOrder extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'fulfillment_order';
+
+
+    /**
+     * @inheritDoc
+     */
+    protected $customPostActions = array(
+        'close',
+        'open',
+        'cancel',
+		'move',
+		'reschedule'
+    );
+}

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -49,6 +49,7 @@ class Order extends ShopifyResource
      */
     protected $childResource = array (
         'Fulfillment',
+		'FulfillmentOrder',
         'OrderRisk' => 'Risk',
         'Refund',
         'Transaction',


### PR DESCRIPTION
Only the section that can be called from the order id using the URL

GET /admin/api/2021-04/orders/{order_id}/fulfillment_orders.json

Is complete. I have tested it and it works on my project and is helpful when getting orders from shopify and determining where they will need to be fulfilled