### PR TITLE
Update CurlRequest.php

### DIFF
--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -56,6 +56,7 @@ class CurlRequest
 
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_USERAGENT, 'PHPClassic/PHPShopify');
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
         $headers = array();
         foreach ($httpHeaders as $key => $value) {


### PR DESCRIPTION
curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); is required if the owner of the Shopify private app ever changes their domain as Shopify will just trigger a 302 error.