### PR TITLE
resend requests that returns http error

### DIFF
--- a/lib/HttpRequestGraphQL.php
+++ b/lib/HttpRequestGraphQL.php
@@ -68,8 +68,8 @@ class HttpRequestGraphQL extends HttpRequestJson
     {
         self::prepareRequest($httpHeaders, $data, $variables);
 
-        $response = CurlRequest::post($url, self::$postDataGraphQL, self::$httpHeaders);
+        self::$postDataJSON = self::$postDataGraphQL;
 
-        return self::processResponse($response);
+        return self::processRequest('POST', $url);
     }
 }

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -526,25 +526,6 @@ abstract class ShopifyResource
     {
         self::$lastHttpResponseHeaders = CurlRequest::$lastHttpResponseHeaders;
 
-        if ($responseArray === null) {
-            //Something went wrong, Checking HTTP Codes
-            $httpOK = 200; //Request Successful, OK.
-            $httpCreated = 201; //Create Successful.
-            $httpDeleted = 204; //Delete Successful
-            $httpOther = 303; //See other (headers).
-
-            //should be null if any other library used for http calls
-            $httpCode = CurlRequest::$lastHttpCode;
-
-            if ($httpCode == $httpOther && array_key_exists('location', self::$lastHttpResponseHeaders)) {
-                return ['location' => self::$lastHttpResponseHeaders['location']];
-            }
-
-            if ($httpCode != null && $httpCode != $httpOK && $httpCode != $httpCreated && $httpCode != $httpDeleted) {
-                throw new Exception\CurlException("Request failed with HTTP Code $httpCode.", $httpCode);
-            }
-        }
-
         $lastResponseHeaders = CurlRequest::$lastHttpResponseHeaders;
         $this->getLinks($lastResponseHeaders);
 


### PR DESCRIPTION
Sometime for temporary issue, shopify http request fail, for example I found in my test logs:

```
Request failed with HTTP Code 520
Request failed with HTTP Code 503
OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 104
```

If you try again a moment later, same requests are ok.

This implementation try to mitigate this problem.

I add a configuration parameters `RequestRetryCallback` that allow to define a callback to manage or log the retry.
The callback take 3 input parameter: raw curl response, exception object and retry number. 
If this callback return true (or non null value) another attempt will be performed.

By default this callback is not defined and this does not change the original behavior of the library.

For example
```php
PHPShopify\ShopifySDK::config([
    'ShopUrl' => SHOPIFY_URL,
    'AccessToken' => SHOPIFY_API_PASSWORD,
    'RequestRetryCallback' => function($response, $error, $retry) {
        echo "retry n=$retry: " . $error->getMessage() . "\n";
        sleep(1); 
        return $retry <= 5;
    }
]);
```


This is a modified version of #234 after @tareqtms advice.