### PR TITLE
FulfillmentOrder hold and release_hold methods

### DIFF
--- a/lib/FulfillmentOrder.php
+++ b/lib/FulfillmentOrder.php
@@ -23,7 +23,8 @@ namespace PHPShopify;
  * @method array close()       Close a fulfillment order
  * @method array move()			Move a fulfilment order to a new location
  * @method array reschedule()	Reschedule fulfill_at_time of a scheduled fulfillment order
- *
+ * @method array hold(array $data)  Hold a fulfillment order
+ * @method array release_hold()     Release hold on a fulfillment order
  */
 class FulfillmentOrder extends ShopifyResource
 {
@@ -41,6 +42,8 @@ class FulfillmentOrder extends ShopifyResource
         'open',
         'cancel',
 		'move',
-		'reschedule'
+		'reschedule',
+        'hold',
+        'release_hold'
     );
 }

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -130,6 +130,7 @@ use PHPShopify\Exception\SdkException;
  * @method DiscountCode DiscountCode(integer $id = null)
  * @method Event Event(integer $id = null)
  * @method FulfillmentService FulfillmentService(integer $id = null)
+ * @method FulfillmentOrder FulfillmentOrder(integer $id = null)
  * @method GiftCard GiftCard(integer $id = null)
  * @method InventoryItem InventoryItem(integer $id = null)
  * @method InventoryLevel InventoryLevel(integer $id = null)
@@ -183,6 +184,7 @@ class ShopifySDK
         'DraftOrder',
         'Event',
         'FulfillmentService',
+        'FulfillmentOrder',
         'GiftCard',
         'InventoryItem',
         'InventoryLevel',


### PR DESCRIPTION
- added `hold` and `release_hold` methods introducted in version [2021-10](https://shopify.dev/api/admin-rest/2021-10/resources/fulfillmentorder#[post]/admin/api/2021-10/fulfillment_orders/{fulfillment_order_id}/hold.json)
- added `FulfillmentOrder` as top level resource