### PR TITLE
Migrating from value_type to type

### DIFF
--- a/tests/MetafieldTest.php
+++ b/tests/MetafieldTest.php
@@ -17,7 +17,7 @@ class MetafieldTest extends TestSimpleResource
         "namespace" => "inventory",
         "key" => "warehouse",
         "value" => 25,
-        "value_type" => "integer",
+        "type" => "integer",
     );
 
     /**
@@ -25,6 +25,6 @@ class MetafieldTest extends TestSimpleResource
      */
     public $putArray = array(
         "value" => "something new",
-        "value_type" => "string",
+        "type" => "string",
     );
 }


### PR DESCRIPTION
In API version 2021-07, Shopify introduced a commerce-oriented type system:

- In the REST Admin API, the type property replaces the value_type property in the Metafield resource.
- In the GraphQL Admin API, the type field replaces the value_type field in the Metafield object.


[https://shopify.dev/apps/metafields/types](url)