### PR TITLE
Add Metafield property and method to docblock

### DIFF
--- a/lib/SmartCollection.php
+++ b/lib/SmartCollection.php
@@ -15,8 +15,10 @@ namespace PHPShopify;
  * SmartCollection -> Child Resources
  * --------------------------------------------------------------------------
  * @property-read Event $Event
+ * @property-read Metafield $Metafield
  *
  * @method Event Event(integer $id = null)
+ * @method Metafield Metafield(integer $id = null)
  *
  * --------------------------------------------------------------------------
  * SmartCollection -> Custom actions


### PR DESCRIPTION
SmartCollection has Metafield support, but static analysis will complain unless it is described in the docblock.