### PR TITLE
Metafield as a child resource of Collection & DraftOrder

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -8,8 +8,10 @@ namespace PHPShopify;
  * --------------------------------------------------------------------------
  *
  * @property-read Product $Product
+ * @property-read Metafield $Metafield
  *
  * @method Product Product(integer $id = null)
+ * @method Metafield Metafield(integer $id = null)
  *
  * @see https://shopify.dev/docs/admin-api/rest/reference/products/collection
  *
@@ -31,5 +33,6 @@ class Collection extends ShopifyResource
      */
     protected $childResource = array(
         'Product',
+        'Metafield',
     );
 }

--- a/lib/DraftOrder.php
+++ b/lib/DraftOrder.php
@@ -13,6 +13,14 @@ namespace PHPShopify;
 
 /**
  * --------------------------------------------------------------------------
+ * DraftOrder -> Child Resources
+ * --------------------------------------------------------------------------
+ *
+ * @property-read Metafield $Metafield
+ *
+ * @method Metafield Metafield(integer $id = null)
+ *
+ * --------------------------------------------------------------------------
  * DraftOrder -> Custom actions
  * --------------------------------------------------------------------------
  * @method array send_invoice()     Send the invoice for a DraftOrder
@@ -38,5 +46,12 @@ class DraftOrder extends ShopifyResource
      */
     protected $customPutActions = array(
         'complete',
+    );
+
+    /**
+     * @inheritDoc
+     */
+    protected $childResource = array(
+        'Metafield',
     );
 }


### PR DESCRIPTION
Collection & DraftOrder api is now support Metafield
see: https://shopify.dev/api/admin-rest/2022-07/resources/metafield