### PR TITLE
Fulfillment 2022-07 API version

### DIFF
--- a/lib/Fulfillment.php
+++ b/lib/Fulfillment.php
@@ -24,6 +24,7 @@ namespace PHPShopify;
  * @method array complete()     Complete a fulfillment
  * @method array open()         Open a pending fulfillment
  * @method array cancel()       Cancel a fulfillment
+ * @method array update_tracking(array $data) Updates the tracking information for a fulfillment.
  *
  */
 class Fulfillment extends ShopifyResource
@@ -47,5 +48,6 @@ class Fulfillment extends ShopifyResource
         'complete',
         'open',
         'cancel',
+        'update_tracking',
     );
 }

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -85,6 +85,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read DiscountCode $DiscountCode
  * @property-read DraftOrder $DraftOrder
  * @property-read Event $Event
+ * @property-read Fulfillment $Fulfillment
  * @property-read FulfillmentService $FulfillmentService
  * @property-read GiftCard $GiftCard
  * @property-read InventoryItem $InventoryItem
@@ -131,6 +132,7 @@ use PHPShopify\Exception\SdkException;
  * @method DraftOrder DraftOrder(integer $id = null)
  * @method DiscountCode DiscountCode(integer $id = null)
  * @method Event Event(integer $id = null)
+ * @method Fulfillment Fulfillment(integer $id = null)
  * @method FulfillmentService FulfillmentService(integer $id = null)
  * @method FulfillmentOrder FulfillmentOrder(integer $id = null)
  * @method GiftCard GiftCard(integer $id = null)
@@ -186,6 +188,7 @@ class ShopifySDK
         'DiscountCode',
         'DraftOrder',
         'Event',
+        'Fulfillment',
         'FulfillmentService',
         'FulfillmentOrder',
         'GiftCard',


### PR DESCRIPTION
- https://github.com/phpclassic/php-shopify/commit/8b2c2a09e6bed833f7b73eed2e4b6107fcbd0f4a I just added `update_tracking` action for fulfillment
- https://github.com/phpclassic/php-shopify/commit/4d49e3bdfaaea01c5234285391bb0e0c23f3ad91 Some Fulfillment api can be call as parent resource now, so we should enable it, related #268 

> POST /admin/api/2022-07/fulfillments.json
> POST /admin/api/2022-07/fulfillments/1069019872/cancel.json
> POST /admin/api/2022-07/fulfillments/1069019871/update_tracking.json

see: https://shopify.dev/api/admin-rest/2022-07/resources/fulfillment