### PR TITLE
#266 - PHP Deprecated: explode(): Passing null to parameter #2 ($stri…

### DIFF
--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -181,12 +181,15 @@ class CurlRequest
                 break;
             }
 
-            $limitHeader = explode('/', $response->getHeader('X-Shopify-Shop-Api-Call-Limit'), 2);
+            $apiCallLimit = $response->getHeader('X-Shopify-Shop-Api-Call-Limit');
 
-            if (isset($limitHeader[1]) && $limitHeader[0] < $limitHeader[1]) {
-                throw new ResourceRateLimitException($response->getBody());
+            if (!empty($apiCallLimit)) {
+                $limitHeader = explode('/', $apiCallLimit, 2);
+                if (isset($limitHeader[1]) && $limitHeader[0] < $limitHeader[1]) {
+                    throw new ResourceRateLimitException($response->getBody());
+                }
             }
-
+            
             $retryAfter = $response->getHeader('Retry-After');
 
             if ($retryAfter === null) {


### PR DESCRIPTION
PHP Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/vendor/phpclassic/php-shopify/lib/CurlRequest.php on line 184 #266