### PR TITLE
Curl Callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,21 @@ $config['ShopifyApiFeatures'] = ['include-presentment-prices'];
 $shopify = new PHPShopify\ShopifySDK($config);
 ```
 
+### ShopifySDK Request callback
+
+Sometimes you will want to log all of your requests, you can setup a global logging callback, that will be triggered after the curl request has been made.
+
+```
+// set the logging callback
+\PHPShopify\CurlRequest::setCurlCallback(function(CurlResponse $response){
+
+    Log::info('Shopify API Request', [
+        'body' => $response->getBody(),
+        'headers' => $response->getHeaders(),
+    ]);
+
+});
+
 
 ## Reference
 - [Shopify API Reference](https://help.shopify.com/api/reference/)

--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -43,6 +43,12 @@ class CurlRequest
     protected static $config = array();
 
     /**
+     * User callback to get the response
+     * @closure
+     */
+    protected static $curlCallback;
+
+    /**
      * Initialize the curl resource
      *
      * @param string $url
@@ -208,7 +214,33 @@ class CurlRequest
 
         self::$lastHttpResponseHeaders = $response->getHeaders();
 
+        // call the user callback with the response
+        self::callCurlCallback($response);
+
         return $response->getBody();
     }
 
+    /**
+     * set the user callback to be called after the curl request
+     *
+     * @param  closure $userCallback
+     * @return void
+     */
+    public static function setCurlCallback($curlCallback)
+    {
+        self::$curlCallback = $curlCallback;
+    }
+
+    /**
+     * call the user callback and pass the response
+     *
+     * @param  CurlResponse $response
+     * @return CurlResponse
+     */
+    protected static function callCurlCallback($response)
+    {
+        if (self::$curlCallback) {
+            return call_user_func(self::$curlCallback, $response);
+        }
+    }
 }


### PR DESCRIPTION
I've been working on extending some of the functionality of the `phpclassic/php-shopify` library as a Laravel Service Provider.  One of the things that I wish I could do for every Curl request is to log the curl headers and response in a centralized place, rather than calling `\PHPShopify\CurlRequest::$lastHttpResponseHeaders;` After every API request that I make.  

So I have added a feature that allows a user to set a callback to receive the `CurlResponse` information after every response.

Usage: 
```php
\PHPShopify\CurlRequest::setCurlCallback(function($response) {

    // do something with the curl response data

    \Log::info('Shopify API Response', [
            'shopify_response_headers' => $response->getHeaders(),
    ]);
});
```

I hope others will find this functionality useful.  Thank you for the consideration. 