### PR TITLE
add support for Order()->FulfillmentOrder and FulfillmentRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ Some resources are available directly, some resources are only available through
 - [DiscountCode](https://help.shopify.com/en/api/reference/discounts/discountcode)
 - [Event](https://help.shopify.com/api/reference/event/)
 - [FulfillmentService](https://help.shopify.com/api/reference/fulfillmentservice)
+- [Fulfillment](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillment)
+- [FulfillmentOrder](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillmentorder)
+- FulfillmentOrder -> [FulfillmentRequest](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillmentrequest)
+- FulfillmentOrder -> [Fulfillment](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillment)
 - [GiftCard](https://help.shopify.com/api/reference/gift_card) _(Shopify Plus Only)_
 - [InventoryItem](https://help.shopify.com/api/reference/inventoryitem)
 - [InventoryLevel](https://help.shopify.com/api/reference/inventorylevel)
@@ -358,8 +362,7 @@ Some resources are available directly, some resources are only available through
 - [Metafield](https://help.shopify.com/api/reference/metafield)
 - [Multipass](https://help.shopify.com/api/reference/multipass) _(Shopify Plus Only, API not available yet)_
 - [Order](https://help.shopify.com/api/reference/order)
-- Order -> [Fulfillment](https://help.shopify.com/api/reference/fulfillment)
-- Order -> Fulfillment -> [Event](https://help.shopify.com/api/reference/fulfillmentevent)
+- Order -> [FulfillmentOrder](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillmentorder)
 - Order -> [Risk](https://help.shopify.com/api/reference/order_risks)
 - Order -> [Refund](https://help.shopify.com/api/reference/refund)
 - Order -> [Transaction](https://help.shopify.com/api/reference/transaction)

--- a/lib/FulfillmentOrder.php
+++ b/lib/FulfillmentOrder.php
@@ -1,8 +1,5 @@
 <?php
 /**
- * Created by PhpStorm.
- * @author Mark Solly <mark@solly.com.au>
- * Created at 5/21/21 11:27 AM UTC+10:00
  *
  * @see https://shopify.dev/docs/admin-api/rest/reference/shipping-and-fulfillment/fulfillmentorder Shopify API Reference for Fulfillment Order
  */
@@ -15,6 +12,7 @@ namespace PHPShopify;
  * FulfillmentOrder -> Child Resources
  * --------------------------------------------------------------------------
  * @property-read FulfillmentRequest $FulfillmentRequest
+ * @property-read Fulfillment $Fulfillment
  *
  * --------------------------------------------------------------------------
  * Fulfillment -> Custom actions
@@ -38,7 +36,8 @@ class FulfillmentOrder extends ShopifyResource
      * @inheritDoc
      */
     protected $childResource = array (
-        'FulfillmentRequest'
+        'FulfillmentRequest',
+        'Fulfillment'
     );
 
     /**

--- a/lib/FulfillmentOrder.php
+++ b/lib/FulfillmentOrder.php
@@ -14,6 +14,7 @@ namespace PHPShopify;
  * --------------------------------------------------------------------------
  * FulfillmentOrder -> Child Resources
  * --------------------------------------------------------------------------
+ * @property-read FulfillmentRequest $FulfillmentRequest
  *
  * --------------------------------------------------------------------------
  * Fulfillment -> Custom actions
@@ -33,6 +34,12 @@ class FulfillmentOrder extends ShopifyResource
      */
     protected $resourceKey = 'fulfillment_order';
 
+    /**
+     * @inheritDoc
+     */
+    protected $childResource = array (
+        'FulfillmentRequest'
+    );
 
     /**
      * @inheritDoc

--- a/lib/FulfillmentRequest.php
+++ b/lib/FulfillmentRequest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Tareq Mahmood <tareqtms@yahoo.com>
+ * Created at 8/19/16 5:28 PM UTC+06:00
+ *
+ * @see https://help.shopify.com/api/reference/fulfillmentservice Shopify API Reference for FulfillmentService
+ */
+
+namespace PHPShopify;
+
+/**
+ * --------------------------------------------------------------------------
+ * FulfillmentRequest -> Child Resources
+ * --------------------------------------------------------------------------
+ *
+ * --------------------------------------------------------------------------
+ * FulfillmentRequest -> Custom actions
+ * --------------------------------------------------------------------------
+ * @method array accept()     Accept a fulfilment order
+ * @method array reject()     Rejects a fulfillment order
+ */
+class FulfillmentRequest extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'fulfillment_request';
+
+    /**
+     * @inheritDoc
+     */
+    public $countEnabled = false;
+
+    /**
+     * @inheritDoc
+     */
+    protected $customPostActions = array(
+        'accept',
+        'reject'
+    );
+
+    protected function pluralizeKey()
+    {
+        return $this->resourceKey;
+    }
+}

--- a/lib/Order.php
+++ b/lib/Order.php
@@ -15,6 +15,7 @@ namespace PHPShopify;
  * --------------------------------------------------------------------------
  * Order -> Child Resources
  * --------------------------------------------------------------------------
+ * @property-read FulfillmentOrder $FulfillmentOrder
  * @property-read Fulfillment $Fulfillment
  * @property-read OrderRisk $Risk
  * @property-read Refund $Refund


### PR DESCRIPTION
This pull request aims to support the behavior required by:
https://shopify.dev/apps/fulfillment/order-management-apps/manage-fulfillments#request-a-fulfillment
https://shopify.dev/api/admin-rest/2022-10/resources/assignedfulfillmentorder

+ FulfillmentRequest Resource - including actions
+ Mapped FulfillmentOrder->FulfillmentRequest 
+ Mapped Order(id)->FulfillmentOrder

Example:
```php
// Requesting the FulfilmentOrder for a given order
$fo = $client->Order("1234567890")->FulfillmentOrder()->get();

// Creating a FulfilmentRequest
// Follow instructions to get partial fulfilments
$fr = $client->FulfillmentOrder('0987654321')->FulfillmentRequest->post([]);

// Accepting \ Rejecting a FulfilmentRequest
$fr = $client->FulfillmentOrder('0987654321')->FulfillmentRequest->accept();
$fr = $client->FulfillmentOrder('0987654321')->FulfillmentRequest->reject();

// Communicating fulfillment
$client->Fulfillment->post($body)
```
