### PR TITLE
Feature - Added API Deprecations Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Some resources are available directly, some resources are only available through
 > Use the resources only by listed resource map. Trying to get a resource directly which is only available through parent resource may end up with errors.
 
 - [AbandonedCheckout](https://help.shopify.com/api/reference/abandoned_checkouts)
+- [ApiDeprecations](https://shopify.dev/api/admin-rest/2022-04/resources/deprecated-api-calls#get-deprecated-api-calls)
 - [ApplicationCharge](https://help.shopify.com/api/reference/applicationcharge)
 - [Blog](https://help.shopify.com/api/reference/blog/)
 - Blog -> [Article](https://help.shopify.com/api/reference/article/)

--- a/lib/ApiDeprecations.php
+++ b/lib/ApiDeprecations.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Tareq Mahmood <tareqtms@yahoo.com>
+ * @author Steve Barbera <whobutsb@gmail.com>
+ * Created at 8/18/16 3:39 PM UTC+06:00
+ *
+ * @see https://shopify.dev/api/admin-rest/2022-04/resources/deprecated-api-calls#get-deprecated-api-calls Shopify API Reference for API Deprecations
+ */
+
+namespace PHPShopify;
+
+
+class ApiDeprecations extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'deprecated_api_calls';
+
+    /**
+     * @inheritDoc
+     */
+    public $readOnly = true;
+
+    /**
+     * @inheritDoc
+     */
+    public $countEnabled = false;
+
+    /**
+     * @inheritDoc
+     */
+    public function pluralizeKey()
+    {
+        //Only api deprecations, so no pluralize
+        return 'deprecated_api_calls';
+    }
+}

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -69,6 +69,7 @@ use PHPShopify\Exception\SdkException;
 /**
  * @property-read AbandonedCheckout $AbandonedCheckout
  * @property-read AccessScope $AccessScope
+ * @property-read ApiDeprecations $ApiDeprecations
  * @property-read ApplicationCharge $ApplicationCharge
  * @property-read Blog $Blog
  * @property-read CarrierService $CarrierService
@@ -116,6 +117,7 @@ use PHPShopify\Exception\SdkException;
  *
  * @method AbandonedCheckout AbandonedCheckout(integer $id = null)
  * @method AccessScope AccessScope()
+ * @method ApiDeprecations ApiDeprecations()
  * @method ApplicationCharge ApplicationCharge(integer $id = null)
  * @method Blog Blog(integer $id = null)
  * @method CarrierService CarrierService(integer $id = null)
@@ -172,6 +174,7 @@ class ShopifySDK
     protected $resources = array(
         'AbandonedCheckout',
         'AccessScope',
+        'ApiDeprecations',
         'ApplicationCharge',
         'Blog',
         'CarrierService',


### PR DESCRIPTION
I have added a new Shopify API Resource to retrieve the Shopify API Deprecations that Shopify has logged in their system.  This is helpful for developers to stay up to date with deprecations that are coming up in the future.  The resource returns an array of API deprecations example: 

```
[0]=>
  array(8) {
    ["api_type"]=>
    string(4) "REST"
    ["description"]=>
    string(83) "Some customer fields have been deprecated from the Admin REST API's Order resource."
    ["documentation_url"]=>
    string(88) "https://shopify.dev/changelog/property-deprecations-in-the-rest-admin-api-order-resource"
    ["endpoint"]=>
    string(5) "Order"
    ["last_call_at"]=>
    string(27) "2022-12-13T16:59:32.000000Z"
    ["migration_deadline"]=>
    string(27) "2023-04-01T15:00:00.000000Z"
    ["graphql_schema_name"]=>
    NULL
    ["version"]=>
    string(7) "2022-07"
  }
```

**Usage**
`$shopify->ApiDeprecations()->get()`

**More Information**
https://shopify.dev/api/admin-rest/2022-04/resources/deprecated-api-calls#get-deprecated-api-calls

Thank you for the consideration of this PR, my team and myself would find this as a helpful inclusion to the library.  

PS - I also have submitted a PR for Callbacks after Curl requests, would it be possible to include this in the library as well?   https://github.com/phpclassic/php-shopify/pull/276
