### PR TITLE
Add total time spent in sleep during multiple requests

### DIFF
--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -36,6 +36,13 @@ class CurlRequest
     public static $lastHttpResponseHeaders = array();
 
     /**
+     * Total time spent in sleep during multiple requests (in seconds)
+     *
+     * @var int
+     */
+    public static $totalRetrySleepTime = 0;
+
+    /**
      * Curl additional configuration
      *
      * @var array
@@ -196,6 +203,7 @@ class CurlRequest
                 break;
             }
 
+            self::$totalRetrySleepTime += (float)$retryAfter;
             sleep((float)$retryAfter);
         }
 
@@ -210,5 +218,4 @@ class CurlRequest
 
         return $response->getBody();
     }
-
 }


### PR DESCRIPTION
Currently, it is not possible to see the past sleep time due to rate limit exceeded during multiple requests of an integration flow. With this modification, it is possible to call the static variable "CurlRequest::$totalRetrySleepTime" from outside in order to know the actual total time spent in sleep.