### PR TITLE
Add support for AssignedFulfillmentOrder resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ Some resources are available directly, some resources are only available through
 - [AbandonedCheckout](https://help.shopify.com/api/reference/abandoned_checkouts)
 - [ApiDeprecations](https://shopify.dev/api/admin-rest/2022-04/resources/deprecated-api-calls#get-deprecated-api-calls)
 - [ApplicationCharge](https://help.shopify.com/api/reference/applicationcharge)
+- [AssignedFulfillmentOrder](https://shopify.dev/docs/api/admin-rest/2023-04/resources/assignedfulfillmentorder#get-assigned-fulfillment-orders)
 - [Blog](https://help.shopify.com/api/reference/blog/)
 - Blog -> [Article](https://help.shopify.com/api/reference/article/)
 - Blog -> Article -> [Event](https://help.shopify.com/api/reference/event/)
@@ -520,9 +521,12 @@ The custom methods are specific to some resources which may not be available for
 - Mapped FulfillmentOrder->FulfillmentRequest
 - Mapped Order(id)->FulfillmentOrder
 
-```
+```php
 // Requesting the FulfilmentOrder for a given order
 $fo = $client->Order("1234567890")->FulfillmentOrder()->get();
+
+// Requesting assigned fulfillment orders (with status fulfillment_requested)
+$shopify->AssignedFulfillmentOrder()->get(["assignment_status" => "fulfillment_requested"]);
 
 // Creating a FulfilmentRequest
 // Follow instructions to get partial fulfilments

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Some resources are available directly, some resources are only available through
 - [AbandonedCheckout](https://help.shopify.com/api/reference/abandoned_checkouts)
 - [ApiDeprecations](https://shopify.dev/api/admin-rest/2022-04/resources/deprecated-api-calls#get-deprecated-api-calls)
 - [ApplicationCharge](https://help.shopify.com/api/reference/applicationcharge)
-- [AssignedFulfillmentOrder](https://shopify.dev/docs/api/admin-rest/2023-04/resources/assignedfulfillmentorder#get-assigned-fulfillment-orders)
+- [AssignedFulfillmentOrder](https://shopify.dev/docs/api/admin-rest/2023-04/resources/assignedfulfillmentorder)
 - [Blog](https://help.shopify.com/api/reference/blog/)
 - Blog -> [Article](https://help.shopify.com/api/reference/article/)
 - Blog -> Article -> [Event](https://help.shopify.com/api/reference/event/)

--- a/lib/AssignedFulfillmentOrder.php
+++ b/lib/AssignedFulfillmentOrder.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ *
+ * @see https://shopify.dev/docs/api/admin-rest/2023-04/resources/assignedfulfillmentorder Shopify API Reference for Assigned Fulfillment Order
+ */
+
+namespace PHPShopify;
+
+
+class AssignedFulfillmentOrder extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'assigned_fulfillment_order';
+}

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -68,6 +68,7 @@ use PHPShopify\Exception\SdkException;
 
 /**
  * @property-read AbandonedCheckout $AbandonedCheckout
+ * @property-read AssignedFulfillmentOrder $AssignedFulfillmentOrder
  * @property-read AccessScope $AccessScope
  * @property-read ApiDeprecations $ApiDeprecations
  * @property-read ApplicationCharge $ApplicationCharge
@@ -116,6 +117,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read GraphQL $GraphQL
  *
  * @method AbandonedCheckout AbandonedCheckout(integer $id = null)
+ * @method AssignedFulfillmentOrder AssignedFulfillmentOrder(string $assignment_status = null, array $location_ids = null)
  * @method AccessScope AccessScope()
  * @method ApiDeprecations ApiDeprecations()
  * @method ApplicationCharge ApplicationCharge(integer $id = null)
@@ -173,6 +175,7 @@ class ShopifySDK
      */
     protected $resources = array(
         'AbandonedCheckout',
+		'AssignedFulfillmentOrder',
         'AccessScope',
         'ApiDeprecations',
         'ApplicationCharge',


### PR DESCRIPTION
This pull request supports the AssignedFulfillmentOrder resource:
https://shopify.dev/docs/api/admin-rest/2023-04/resources/assignedfulfillmentorder

AssignedFulfillmentOrder Resource

Example:
```php
// Requesting all assigned fulfillment orders
$shopify->AssignedFulfillmentOrder()->get();

// Requesting assigned fulfillment orders (by status)
$shopify->AssignedFulfillmentOrder()->get(["assignment_status" => "fulfillment_requested"]);

// Requesting assigned fulfillment orders (by locations)
$shopify->AssignedFulfillmentOrder()->get(["location_ids" => ["123456789"]]);
```