### PR TITLE
Resource/Object specific data key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ The custom methods are specific to some resources which may not be available for
 $fo = $client->Order("1234567890")->FulfillmentOrder()->get();
 
 // Requesting assigned fulfillment orders (with status fulfillment_requested)
-$shopify->AssignedFulfillmentOrder()->get(["assignment_status" => "fulfillment_requested"]);
+$fo = $client->AssignedFulfillmentOrder()->get(["assignment_status" => "fulfillment_requested"]);
 
 // Creating a FulfilmentRequest
 // Follow instructions to get partial fulfilments

--- a/lib/AssignedFulfillmentOrder.php
+++ b/lib/AssignedFulfillmentOrder.php
@@ -13,4 +13,9 @@ class AssignedFulfillmentOrder extends ShopifyResource
      * @inheritDoc
      */
     protected $resourceKey = 'assigned_fulfillment_order';
+
+	/**
+	 * @inheritDoc
+	 */
+	protected $dataKey = 'fulfillment_orders';
 }


### PR DESCRIPTION
This PR attempts to support resource/object level data keys _as well as_ request level.

As example:
The recently added `AssignedFulfillmentOrder` resource. It returns results with the `fulfillment_orders` key, which does not match the resource key.

While a data key can be manually passed to `get()`, it feels messy for a resource which _always_ requires a custom data key.

Setting the protected `$dataKey` property in a resource object will cause the specified key to be used with results (unless a key is provided manually).

(Therefore, this PR "fixes" the response payload from `AssignedFulfillmentOrder`)

