### PR TITLE
Gift Card Adjustment Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Some resources are available directly, some resources are only available through
 - FulfillmentOrder -> [FulfillmentRequest](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillmentrequest)
 - FulfillmentOrder -> [Fulfillment](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillment)
 - [GiftCard](https://help.shopify.com/api/reference/gift_card) _(Shopify Plus Only)_
+- [GiftCardAdjustment](https://shopify.dev/docs/api/admin-rest/2023-01/resources/gift-card-adjustment) _(Shopify Plus Only)_
 - [InventoryItem](https://help.shopify.com/api/reference/inventoryitem)
 - [InventoryLevel](https://help.shopify.com/api/reference/inventorylevel)
 - [Location](https://help.shopify.com/api/reference/location/) _(read only)_

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Some resources are available directly, some resources are only available through
 - FulfillmentOrder -> [FulfillmentRequest](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillmentrequest)
 - FulfillmentOrder -> [Fulfillment](https://shopify.dev/api/admin-rest/2023-01/resources/fulfillment)
 - [GiftCard](https://help.shopify.com/api/reference/gift_card) _(Shopify Plus Only)_
-- [GiftCardAdjustment](https://shopify.dev/docs/api/admin-rest/2023-01/resources/gift-card-adjustment) _(Shopify Plus Only)_
+- GiftCard -> [Adjustment](https://shopify.dev/docs/api/admin-rest/2023-01/resources/gift-card-adjustment) _(Shopify Plus Only)_
 - [InventoryItem](https://help.shopify.com/api/reference/inventoryitem)
 - [InventoryLevel](https://help.shopify.com/api/reference/inventorylevel)
 - [Location](https://help.shopify.com/api/reference/location/) _(read only)_

--- a/lib/GiftCard.php
+++ b/lib/GiftCard.php
@@ -45,4 +45,11 @@ class GiftCard extends ShopifyResource
 
         return $this->post($dataArray, $url);
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected $childResource = array(
+        'GiftCardAdjustment' => 'Adjustment'
+    );
 }

--- a/lib/GiftCardAdjustment.php
+++ b/lib/GiftCardAdjustment.php
@@ -6,6 +6,26 @@
  *
  * @see https://shopify.dev/docs/api/admin-rest/2023-01/resources/gift-card-adjustment Shopify API Reference for Gift Card Adjustment
  * @note - requires gift_card_adjustments access scope enabled by Shopify Support
+ *
+ * @usage: 
+ *
+    $shopify = \PHPShopify\ShopifySDK::config($config);
+
+    $gift_card_id = 88888888888;
+
+    $gift_card_adjustment_id = 999999999999;
+
+    // Get all gift card adjustments
+    $shopify->GiftCard($gift_card_id)->Adjustment()->get();
+
+    // Get a single gift card adjustment
+    $shopify->GiftCard($gift_card_id)->Adjustment($gift_card_adjustment_id)->get();
+
+    // Create a gift card adjustment
+    $shopify->GiftCard($gift_card_id)->Adjustment()->post([
+        'amount' => 5,
+        'note' => 'Add $5 to gift card'
+    ]);
  */
 
 namespace PHPShopify;

--- a/lib/GiftCardAdjustment.php
+++ b/lib/GiftCardAdjustment.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * @author Tareq Mahmood <tareqtms@yahoo.com>
+ * Created at: 8/21/16 8:39 AM UTC+06:00
+ *
+ * @see https://shopify.dev/docs/api/admin-rest/2023-01/resources/gift-card-adjustment Shopify API Reference for Gift Card Adjustment
+ * @note - requires gift_card_adjustments access scope enabled by Shopify Support
+ */
+
+namespace PHPShopify;
+
+
+class GiftCardAdjustment extends ShopifyResource
+{
+    /**
+     * @inheritDoc
+     */
+    protected $resourceKey = 'adjustment';
+}

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -90,6 +90,7 @@ use PHPShopify\Exception\SdkException;
  * @property-read Fulfillment $Fulfillment
  * @property-read FulfillmentService $FulfillmentService
  * @property-read GiftCard $GiftCard
+ * @property-read GiftCardAdjustment $GiftCardAdjustment
  * @property-read InventoryItem $InventoryItem
  * @property-read InventoryLevel $InventoryLevel
  * @property-read Location $Location
@@ -140,6 +141,7 @@ use PHPShopify\Exception\SdkException;
  * @method FulfillmentService FulfillmentService(integer $id = null)
  * @method FulfillmentOrder FulfillmentOrder(integer $id = null)
  * @method GiftCard GiftCard(integer $id = null)
+ * @method GiftCardAdjustment GiftCardAdjustment(integer $id = null)
  * @method InventoryItem InventoryItem(integer $id = null)
  * @method InventoryLevel InventoryLevel(integer $id = null)
  * @method Location Location(integer $id = null)
@@ -261,6 +263,7 @@ class ShopifySDK
         'Dispute'           => 'ShopifyPayment',
         'Fulfillment'       => 'Order',
         'FulfillmentEvent'  => 'Fulfillment',
+        'GiftCardAdjustment'=> 'GiftCard',
         'OrderRisk'         => 'Order',
         'Payouts'           => 'ShopifyPayment',
         'ProductImage'      => 'Product',


### PR DESCRIPTION
Added the Gift Card Adjustment Resource to list adjustments and increment and decrement amounts on gift cards.

This is a Shopify Plus only feature and requires you to contact Shopify Support to enable the `gift_card_adjustments` access scope. 

API Documentation - https://shopify.dev/docs/api/admin-rest/2023-01/resources/gift-card-adjustment

**Usage**

```php
$config = array(
    'ShopUrl' => 'my-store.myshopify.com',
    'AccessToken' => 'shpat_999999999999999999999'
);

$shopify = \PHPShopify\ShopifySDK::config($config);

$gift_card_id = 88888888888;

$gift_card_adjustment_id = 999999999999;

// Get all gift card adjustments
$shopify->GiftCard($gift_card_id)->Adjustment()->get();

// Get a single gift card adjustment
$shopify->GiftCard($gift_card_id)->Adjustment($gift_card_adjustment_id)->get();

// Create a gift card adjustment
$shopify->GiftCard($gift_card_id)->Adjustment()->post([
    'amount' => 5,
    'note' => 'Add $5 to gift card'
]);
```

PS - Could you also please consider - https://github.com/phpclassic/php-shopify/pull/276 😃 