### PR TITLE
RecurringApplicationCharge compatibility with latest Shopify API

### DIFF
--- a/lib/RecurringApplicationCharge.php
+++ b/lib/RecurringApplicationCharge.php
@@ -51,6 +51,68 @@ class RecurringApplicationCharge extends ShopifyResource
     );
 
     /*
+     * Create a recurring application charge
+     *
+     * @param array $data
+     *
+     * @return array
+     *
+     */
+    public function create($dataArray)
+    {
+        $dataArray = $this->wrapData($dataArray);
+
+        $url = $this->generateUrl($dataArray);
+
+        $response = $this->post(array(), $url);
+
+        return $response;
+    }
+
+    /**
+     * Get list of all charges
+     * 
+     * @return array
+     */
+    public function charges(){
+        $url = $this->generateUrl();
+
+        $response = $this->get(array(), $url);
+
+        return $response;
+    }
+
+    /**
+     * Get details of a single charge
+     * 
+     * @param $charge_id
+     * 
+     * @return array
+     */
+    public function charge( $charge_id ){
+        $url = $this->generateUrl(array(), $charge_id);
+
+        $response = $this->get(array(), $url);
+
+        return $response;
+    }
+
+    /**
+     * Cancel a recurring charge
+     * 
+     * @param $charge_id
+     * 
+     * @return array
+     */
+    public function cancel($charge_id){
+        $url = $this->generateUrl(array(), $charge_id);
+
+        $response = $this->delete(array(), $url);
+
+        return $response;
+    }
+
+    /*
      * Customize a recurring application charge
      *
      * @param array $data


### PR DESCRIPTION
activate method no longer seem to exist on recurring application charge. Added a few methods based on latest api docs.

1. create: Creates a charge with provided data
2. charges: retrieves a list of charges
3. charge: retrives details of a single charge from the provided charge id
4. cancel: cancels a charge by provided id

