### PR TITLE
Feature: Storefront GraphQL Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,44 @@ $variables = [
 $shopify->GraphQL->post($graphQL, null, null, $variables);
 ```
 
-
 ##### GraphQL Builder
 This SDK only accepts a GraphQL string as input. You can build your GraphQL from [Shopify GraphQL Builder](https://help.shopify.com/en/api/graphql-admin-api/graphiql-builder)
+
+### Storefront GraphQL 
+The [Storefront GraphQL API](https://shopify.dev/docs/api/storefront) allows you to make authenticated requests to access data from a store's storefront. See [Storefront API Authentication](https://shopify.dev/docs/api/storefront#authentication) for more details.
+
+The Storefront GraphQL API uses an alternative url to make requests which follows the format: 
+`https://{shop}.myshopify.com/api/{version}/graphql.json`
+
+Example Usage: 
+```php
+$shopify = \PHPShopify\ShopifySDK::config([
+    'AccessToken' => 'SHOPIFY_ADMIN_TOKEN',
+    'ShopUrl' => 'my-store.myshopify.com',
+    // Required to make requests to the Storefront API
+    'StoreFrontAccessToken' => 'STOREFRONT_ACCESS_TOKEN' 
+]);
+
+$query = <<<GQL
+query Products {
+    products(first: 10) {
+        edges {
+            node {
+                createdAt
+                handle
+                id
+                title
+            }
+        }
+    }
+}
+GQL;
+
+// use the storefront() method
+$products = $shopify->GraphQL->storefront($query);
+```
+
+The `storefront` method uses the same arguments as the `post` method, so you can use variables as well. 
 
 
 ### Resource Mapping

--- a/lib/GraphQL.php
+++ b/lib/GraphQL.php
@@ -50,6 +50,35 @@ class GraphQL extends ShopifyResource
     }
 
     /**
+     * Call POST method to the Storefront GraphQL API
+     *
+     *
+     * @param string $graphQL A valid GraphQL String. @see https://help.shopify.com/en/api/graphql-admin-api/graphiql-builder GraphiQL builder - you can build your graphql string from here.
+     * @param string $url
+     * @param bool $wrapData
+     * @param array|null $variables
+     *
+     * @uses HttpRequestGraphQL::post() to send the HTTP request
+     * @throws ApiException if the response has an error specified
+     * @throws CurlException if response received with unexpected HTTP code.
+     *
+     * @return array
+     * @see https://shopify.dev/docs/api/storefront
+     */
+    public function storefront($graphQL, $url = null, $wrapData = false, $variables = null)
+    {
+        $config = ShopifySDK::$config;
+
+        if (!$url) {
+            $url = 'https://'.$config['ShopUrl'].'/api/'.$config['ApiVersion'].'/graphql.json';
+        }
+
+        $response = HttpRequestGraphQL::post($url, $graphQL, $this->httpHeaders, $variables);
+
+        return $this->processResponse($response);
+    }
+
+    /**
      * @inheritdoc
      * @throws SdkException
      */

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -150,6 +150,10 @@ abstract class ShopifyResource
             throw new SdkException("Either AccessToken or ApiKey+Password Combination (in case of private API) is required to access the resources. Please check SDK configuration!");
         }
 
+        if (isset($config['StoreFrontAccessToken'])) {
+            $this->httpHeaders['X-Shopify-Storefront-Access-Token'] = $config['StoreFrontAccessToken'];
+        }
+
         if (isset($config['ShopifyApiFeatures'])) {
             foreach($config['ShopifyApiFeatures'] as $apiFeature) {
                 $this->httpHeaders['X-Shopify-Api-Features'] = $apiFeature;


### PR DESCRIPTION
I propose adding a new feature to the library enabling users to interact with the [Shopify Storefront GraphQL API](https://shopify.dev/docs/api/storefront). This API necessitates an alternative endpoint for authenticated requests: `https://my-store.myshopify.com/api/2023-04/graphql.json`.

**Key Modifications:**
1. Updated `lib/ShopifyResource.php`:
   - Modified `__construct()` to accept and set a new configuration variable `StoreFrontAccessToken`, obtainable via Shopify Admin under "Private App" setup.
2. Extended `lib/GraphQL.php`:
   - Introduced `storefront()` method, mirroring `post()` method’s signature. If `$url` argument remains unset, it assembles the correct Shopify GraphQL storefront URL for requests.

**Example Usage:**
```php
$shopify = \PHPShopify\ShopifySDK::config([
    'AccessToken' => 'SHOPIFY_ADMIN_TOKEN',
    'ShopUrl' => 'my-store.myshopify.com',
    'StoreFrontAccessToken' => 'STOREFRONT_ACCESS_TOKEN'  // Required for Storefront API requests
]);

$query = <<<GQL
query Products {
    products(first: 10) {
        edges {
            node {
                createdAt
                handle
                id
                title
            }
        }
    }
}
GQL;

// Utilize the storefront() method
$products = $shopify->GraphQL->storefront($query);
```

**Motivation**:
I Encountered a scenario requiring product locale translations retrieval for a client's store. The existing Shopify Admin GraphQL API fell short, necessitating the Storefront API. I appreciate the ease of use this library brings and think this feature would be beneficial to the developers that work with this great library. 

I appreciate any feedback and am open to making any necessary changes. Thank you for considering this enhancement!