### PR TITLE
Content type application/graphql is deprecated

### DIFF
--- a/lib/HttpRequestGraphQL.php
+++ b/lib/HttpRequestGraphQL.php
@@ -45,12 +45,10 @@ class HttpRequestGraphQL extends HttpRequestJson
         }
 
         self::$httpHeaders = $httpHeaders;
+        self::$httpHeaders['Content-type'] = 'application/json';
 
         if (is_array($variables)) {
             self::$postDataGraphQL = json_encode(['query' => $data, 'variables' => $variables]);
-            self::$httpHeaders['Content-type'] = 'application/json';
-        } else {
-            self::$httpHeaders['Content-type'] = 'application/graphql';
         }
     }
 


### PR DESCRIPTION
Details : https://shopify.dev/changelog/content-type-application-graphql-is-deprecated

https://shopify.dev/docs/api/release-notes/2025-01