### PR TITLE
Fixed 400 Bad Request Api Issue with Graphql

### DIFF
--- a/lib/HttpRequestGraphQL.php
+++ b/lib/HttpRequestGraphQL.php
@@ -49,6 +49,8 @@ class HttpRequestGraphQL extends HttpRequestJson
 
         if (is_array($variables)) {
             self::$postDataGraphQL = json_encode(['query' => $data, 'variables' => $variables]);
+        } else {
+            self::$postDataGraphQL = json_encode(['query' => $data]);
         }
     }
 


### PR DESCRIPTION
fixed the 400 bad request api issue with graphql when variables are not passed even if they are not required.