### PR TITLE
Allow custom HTTP client and add Guzzle adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ composer require phpclassic/php-shopify
 ```
 
 ### Requirements
-PHPShopify uses curl extension for handling http calls. So you need to have the curl extension installed and enabled with PHP.
->However if you prefer to use any other available package library for handling HTTP calls, you can easily do so by modifying 1 line in each of the `get()`, `post()`, `put()`, `delete()` methods in `PHPShopify\HttpRequestJson` class.
+PHPShopify relies on the `cURL` extension to perform HTTP requests. Make sure the `cURL` extension is installed and enabled in your PHP environment. Alternatively, you can provide your own HTTP client by implementing the `PHPShopify\HttpClient` interface.
 
 You can pass additional curl configuration to `ShopifySDK`
 ```php
@@ -24,6 +23,19 @@ $config = array(
         CURLOPT_TIMEOUT => 10,
         CURLOPT_FOLLOWLOCATION => true
     )
+);
+
+PHPShopify\ShopifySDK::config($config);
+```
+## Guzzle or Custom HTTP Client
+If you prefer to use a different HTTP library, you can create a custom adapter by implementing the `PHPShopify\HttpClient` interface and passing it via the `HttpClient` configuration option.
+
+For example, using Guzzle is straightforward with the provided adapter:
+```php
+$client = new GuzzleHttp\Client();
+$config = array(
+    // ...  
+    'HttpClient' => new PHPShopify\GuzzleAdapter($client)
 );
 
 PHPShopify\ShopifySDK::config($config);

--- a/lib/AuthHelper.php
+++ b/lib/AuthHelper.php
@@ -173,7 +173,7 @@ class AuthHelper
 
             $response = HttpRequestJson::post($config['AdminUrl'] . 'oauth/access_token', $data);
 
-            if (CurlRequest::$lastHttpCode >= 400) {
+            if (ShopifySDK::getClient()->getLastResponseCode() >= 400) {
                 throw new SdkException("The shop is invalid or the authorization code has already been used.");
             }
 

--- a/lib/CurlAdapter.php
+++ b/lib/CurlAdapter.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PHPShopify;
+
+class CurlAdapter implements HttpClient
+{
+    /**
+     * @param $url
+     * @param $headers
+     *
+     * @return string
+     */
+    public function get($url, $headers = array())
+    {
+        return CurlRequest::get($url, $headers);
+    }
+
+    /**
+     * @param string $url
+     * @param array $data
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function post($url, $data = array(), $headers = array())
+    {
+        return CurlRequest::post($url, json_encode($data), $headers);
+    }
+
+    /**
+     * @param string $url
+     * @param array $data
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function put($url, $data = array(), $headers = array())
+    {
+        return CurlRequest::put($url, json_encode($data), $headers);
+    }
+
+    /**
+     * @param $url
+     * @param $headers
+     *
+     * @return string
+     */
+    public function delete($url, $headers = array())
+    {
+        return CurlRequest::delete($url, $headers);
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastResponseCode()
+    {
+        return CurlRequest::$lastHttpCode;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLastResponseHeaders()
+    {
+        return CurlRequest::$lastHttpResponseHeaders;
+    }
+}

--- a/lib/CurlRequest.php
+++ b/lib/CurlRequest.php
@@ -106,7 +106,7 @@ class CurlRequest
      * Implement a POST request and return output
      *
      * @param string $url
-     * @param array $data
+     * @param string $data
      * @param array $httpHeaders
      *
      * @return string
@@ -125,7 +125,7 @@ class CurlRequest
      * Implement a PUT request and return output
      *
      * @param string $url
-     * @param array $data
+     * @param string $data
      * @param array $httpHeaders
      *
      * @return string

--- a/lib/GuzzleAdapter.php
+++ b/lib/GuzzleAdapter.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace PHPShopify;
+
+class GuzzleAdapter implements HttpClient
+{
+    /**
+     * Guzzle client instance
+     */
+    protected $client;
+
+    protected $lastResponse;
+
+    /**
+     * Pass guzzle http client in constructor
+     *
+     * @param $client
+     */
+    public function __construct($client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @param $url
+     * @param $headers
+     *
+     * @return string
+     */
+    public function get($url, $headers = array())
+    {
+        $this->lastResponse = $this->client->get($url, [
+            'headers' => $headers,
+        ]);
+
+        return $this->getContents();
+    }
+
+    /**
+     * @param string $url
+     * @param array $data
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function post($url, $data = array(), $headers = array())
+    {
+        $options = [
+            'headers' => $headers,
+        ];
+
+        if (!empty($data)) {
+            $options['json'] = $data;
+        }
+
+        $this->lastResponse = $this->client->post($url, $options);
+
+        return $this->getContents();
+    }
+
+    /**
+     * @param string $url
+     * @param array $data
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function put($url, $data = array(), $headers = array())
+    {
+        $options = [
+            'headers' => $headers,
+        ];
+
+        if (!empty($data)) {
+            $options['json'] = $data;
+        }
+
+        $this->lastResponse = $this->client->put($url, $options);
+
+        return $this->getContents();
+    }
+
+    /**
+     * @param $url
+     * @param $headers
+     *
+     * @return string
+     */
+    public function delete($url, $headers = array())
+    {
+        $this->lastResponse = $this->client->delete($url, [
+            'headers' => $headers,
+        ]);
+
+        return $this->getContents();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLastResponse()
+    {
+        return $this->lastResponse;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLastResponseCode()
+    {
+        if (empty($this->lastResponse)) {
+            return 0;
+        }
+
+        return $this->lastResponse->getStatusCode();
+    }
+
+    /**
+     * @return array
+     */
+    public function getLastResponseHeaders()
+    {
+        if (empty($this->lastResponse)) {
+            return array();
+        }
+
+        $result = array();
+
+        foreach ($this->lastResponse->getHeaders() as $name => $value) {
+            $result[strtolower($name)] = $value[0];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getContents()
+    {
+        $contents = '';
+        $body = $this->lastResponse->getBody();
+
+        if ($body) {
+            $contents = $body->getContents();
+            $body->rewind();
+        }
+
+        return $contents;
+    }
+}

--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PHPShopify;
+
+interface HttpClient
+{
+    /**
+     * @param string $url
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function get ($url, $headers = array());
+
+    /**
+     * @param string $url
+     * @param array $data
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function post($url, $data = array(), $headers = array());
+
+    /**
+     * @param string $url
+     * @param array $data
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function put($url, $data = array(), $headers = array());
+
+    /**
+     * @param string $url
+     * @param array $headers
+     *
+     * @return string
+     */
+    public function delete ($url, $headers = array());
+
+    /**
+     * @return int
+     */
+    public function getLastResponseCode();
+
+    /**
+     * @return array
+     */
+    public function getLastResponseHeaders();
+}

--- a/lib/HttpRequestGraphQL.php
+++ b/lib/HttpRequestGraphQL.php
@@ -48,8 +48,10 @@ class HttpRequestGraphQL extends HttpRequestJson
         self::$httpHeaders['Content-type'] = 'application/json';
 
         if (is_array($variables)) {
+            self::$postData = ['query' => $data, 'variables' => $variables];
             self::$postDataGraphQL = json_encode(['query' => $data, 'variables' => $variables]);
         } else {
+            self::$postData = ['query' => $data];
             self::$postDataGraphQL = json_encode(['query' => $data]);
         }
     }

--- a/lib/ShopifyResource.php
+++ b/lib/ShopifyResource.php
@@ -524,10 +524,11 @@ abstract class ShopifyResource
      */
     public function processResponse($responseArray, $dataKey = null)
     {
-        self::$lastHttpResponseHeaders = CurlRequest::$lastHttpResponseHeaders;
+        $client = ShopifySDK::getClient();
 
-        $lastResponseHeaders = CurlRequest::$lastHttpResponseHeaders;
-        $this->getLinks($lastResponseHeaders);
+        self::$lastHttpResponseHeaders = $client->getLastResponseHeaders();
+
+        $this->getLinks(self::$lastHttpResponseHeaders);
 
         if (isset($responseArray['errors'])) {
             $message = $this->castString($responseArray['errors']);
@@ -537,7 +538,7 @@ abstract class ShopifyResource
                 return array('account_activation_url'=>false);
             }
             
-            throw new ApiException($message, CurlRequest::$lastHttpCode);
+            throw new ApiException($message, $client->getLastResponseCode());
         }
 
         if ($dataKey && isset($responseArray[$dataKey])) {

--- a/lib/ShopifySDK.php
+++ b/lib/ShopifySDK.php
@@ -373,6 +373,14 @@ class ShopifySDK
             CurlRequest::config($config['Curl']);
         }
 
+        if (isset($config['HttpClient'])) {
+            if (!$config['HttpClient'] instanceof HttpClient) {
+                throw new \Exception('HttpClient must be an instance of PHPShopify\HttpClient.');
+            }
+        } else {
+            self::$config['HttpClient'] = new CurlAdapter();
+        }
+
         return new ShopifySDK;
     }
 
@@ -474,5 +482,13 @@ class ShopifySDK
         }
 
         static::$microtimeOfLastApiCall = microtime(true);
+    }
+
+    /**
+     * @return HttpClient
+     */
+    public static function getClient()
+    {
+        return self::$config['HttpClient'];
     }
 }


### PR DESCRIPTION
This PR add more flexibility to the library allowing to use custom HTTP clients, like `Guzzle`. There is also simple `GuzzleAdapter` added so developers don't need to write their own and start using package right away. By dafault it still uses `cURL` , however its wrapped in `CurlAdapter`. Both are implementing `HttpClient` interface.

```php
$client = new GuzzleHttp\Client();
$config = array(
    // ...  
    'HttpClient' => new PHPShopify\GuzzleAdapter($client)
);

PHPShopify\ShopifySDK::config($config);
```