### PR TITLE
Throw descriptive API exception messages

### DIFF
--- a/lib/HttpRequestJson.php
+++ b/lib/HttpRequestJson.php
@@ -208,10 +208,35 @@ class HttpRequestJson
             return ['location' => $lastHttpResponseHeaders['location']];
         }
 
-        if (!in_array($httpCode, [null, $httpOK, $httpCreated, $httpDeleted]) || !empty($responseArray['error'])) {
+        if (!in_array($httpCode, [null, $httpOK, $httpCreated, $httpDeleted]) || !empty($responseArray['error'])|| !empty($responseArray['errors'])) {
             $message = "Request failed"
                 . ($httpCode ? " with HTTP Code $httpCode" : "")
                 . (!empty($responseArray['error']) ? ': ' . $responseArray['error'] : '.');
+
+            if (!empty($responseArray['error'])) {
+                $message = "Request failed"
+                    . ($httpCode ? " with HTTP Code $httpCode" : "")
+                    . (!empty($responseArray['error']) ? ': ' . $responseArray['error'] : '.');
+            } elseif (!empty($responseArray['errors'])) {
+                $message = "Request failed"
+                    . ($httpCode ? " with HTTP Code $httpCode: " : ": ");
+
+                if (is_array($responseArray['errors'])) {
+                    $parts = [];
+
+                    foreach ($responseArray['errors'] as $field => $messages) {
+                        if (is_array($messages)) {
+                            $parts[] = $field . ' - ' . implode(', ', $messages);
+                        } else {
+                            $parts[] = $field . ' - ' . $messages;
+                        }
+                    }
+
+                    $message .= implode('; ', $parts);
+                } else {
+                    $message .= $responseArray['errors'];
+                }
+            }
             throw new ApiException($message, $httpCode);
         }
 


### PR DESCRIPTION
Commit https://github.com/phpclassic/php-shopify/commit/9b62f4c1b1717c4f8bc2f130c80c92896bf4a61c prevents detailed error messages from being shown. 

For example, when an API call returns this response:

```
{"errors":{"phone":["is invalid"]}}
```

the exception currently shows only "Request failed with HTTP Code 422". 

This makes it hard to see what actually went wrong.

This merge request brings back the previous behaviour and shows a more descriptive error message, such as "Request failed with HTTP Code 422: phone - is invalid".